### PR TITLE
Enable initial GNU compilation of mpas-seaice within the FullyCoupled compset

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -109,6 +109,13 @@ def _build_mpassi():
 
     with Case(caseroot, read_only=False) as case:
         srcroot = case.get_value("SRCROOT")
+        compiler = case.get_value("COMPILER")
+        if compiler == 'intel':
+            fixedflags =  '-free'
+        elif compiler == 'gnu':
+            fixedflags =  '-ffree-form'
+        else:
+            fixedflags = ''
         # call mpassi's buildcpp to set the cppdefs
         #cmd = os.path.join(os.path.join(srcroot, "components", "mpassi", "cime_config", "buildcpp"))
         #logger.info("     ...calling mpassi buildcpp to set build time options")
@@ -138,28 +145,28 @@ def _build_mpassi():
                 filepath.write("\n")
 
         #build the code that creates the registry *cheyenne, intel specific)
-        cmd = "icc -c ../source/ezxml.c"    
+        cmd = "mpicc -c ../source/ezxml.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/utility.c"    
+        cmd = "mpicc -c ../source/utility.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/fortprintf.c"    
+        cmd = "mpicc -c ../source/fortprintf.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/gen_inc.c"    
+        cmd = "mpicc -c ../source/gen_inc.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/dictionary.c"    
+        cmd = "mpicc -c ../source/dictionary.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -c ../source/parse.c"    
+        cmd = "mpicc -c ../source/parse.c"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "icc -o parse parse.o dictionary.o gen_inc.o fortprintf.o utility.o ezxml.o"
+        cmd = "mpicc -o parse parse.o dictionary.o gen_inc.o fortprintf.o utility.o ezxml.o"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
-        cmd = "cpp -P -traditional -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI -DMPAS_OPENACC -DMPAS_NO_LOG_REDIRECT -DUSE_PIO2 -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_ESM_SHR_CONST -DMPAS_PERF_MOD_TIMERS -DOFFSET64BIT -D_MPI -DMPAS_NAMELIST_SUFFIX= -DMPAS_EXE_NAME= -DCORE_OCEAN -DEXCLUDE_INIT_MODE -DUSE_LAPACK -Uvector Registry.xml > Registry_processed.xml"
+        cmd = "cpp -P -traditional -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI -DMPAS_OPENACC -DMPAS_NO_LOG_REDIRECT -DUSE_PIO2 -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NO_ESMF_INIT -DMPAS_ESM_SHR_CONST -DMPAS_PERF_MOD_TIMERS -DOFFSET64BIT -D_MPI -DMPAS_NAMELIST_SUFFIX= -DMPAS_EXE_NAME= -DCORE_OCEAN -DEXCLUDE_INIT_MODE -DUSE_LAPACK -Uvector Registry.xml > Registry_processed.xml"
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
         cmd = "../obj/parse ../Registry_processed.xml"
@@ -169,8 +176,8 @@ def _build_mpassi():
         # build the library
         makefile = os.path.join(casetools, "Makefile")
         complib = os.path.join(libroot, "libice.a")
-        cmd = "{} complib -j {} MODEL=mpassi COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=seaice\" FIXEDFLAGS=-free {}" \
-            .format(gmake, gmake_j, complib, makefile, get_standard_makefile_args(case))
+        cmd = "{} complib -j {} MODEL=mpassi COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=seaice\" FIXEDFLAGS={} {}" \
+            .format(gmake, gmake_j, complib, makefile, fixedflags, get_standard_makefile_args(case))
 
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))
         expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))

--- a/driver_nuopc/ice_import_export.F90
+++ b/driver_nuopc/ice_import_export.F90
@@ -463,7 +463,7 @@ contains
     call shr_mpi_max(max_med2mod_areacor, max_med2mod_areacor_glob, lmpicom)
     call shr_mpi_min(min_med2mod_areacor, min_med2mod_areacor_glob, lmpicom)
 
-    if (my_task == mastertask) then
+    if (mastertask) then
        write(stdout,'(2A,2g23.15,A )') trim(subname),' :  min_mod2med_areacor, max_mod2med_areacor ',&
             min_mod2med_areacor_glob, max_mod2med_areacor_glob, 'MPASSI'
        write(stdout,'(2A,2g23.15,A )') trim(subname),' :  min_med2mod_areacor, max_med2mod_areacor ',&


### PR DESCRIPTION
This PR makes small fixes and generalizes the rules in mpas-seaice/cime_config/buildlib to allow this component to build with the GNU compiler suite.

NOTE: currently this only enables the build with GNU but the code does not execute correctly. The ability to build and run the FullyCoupled compset with the Intel compilers is unaffected by these changes.