### PR TITLE
Fix Intel OneAPI builds

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -113,7 +113,7 @@ def _build_mpassi():
         if compiler == 'intel':
             fixedflags =  '"-UCPRINTEL -free"'
         elif compiler == 'intel-oneapi':
-            fixedflags =  '-free'
+            fixedflags =  '"-UCPRINTEL -free"'
         elif compiler == 'gnu':
             fixedflags =  '-ffree-form'
         elif compiler == 'nvhpc':

--- a/src/model_forward/mpas_seaice_core_interface.F
+++ b/src/model_forward/mpas_seaice_core_interface.F
@@ -8,7 +8,8 @@ module seaice_core_interface
    use seaice_analysis_driver
    use mpas_log, only: mpas_log_write
 
-   public
+   private
+   public :: seaice_setup_core, seaice_setup_domain
 
    contains
 


### PR DESCRIPTION
This fix addresses an Internal Compiler Error that would occur with only the OneAPI compilers in mpas_seaice_core_interface.F90.