### PR TITLE
Seaice prescribed mode

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -419,6 +419,7 @@ my $CONTINUE_RUN           = "$xmlvars{'CONTINUE_RUN'}";
 
 my $SSTICE_GRID_FILENAME;
 my $SSTICE_DATA_FILENAME;
+my $SSTICE_MESH_FILENAME;
 my $SSTICE_YEAR_ALIGN;
 my $SSTICE_YEAR_START;
 my $SSTICE_YEAR_END;
@@ -426,6 +427,7 @@ my $SSTICE_STREAM;
 if ($prognostic_mode eq 'prescribed') {
     $SSTICE_GRID_FILENAME = $xmlvars{'SSTICE_GRID_FILENAME'};
     $SSTICE_DATA_FILENAME = $xmlvars{'SSTICE_DATA_FILENAME'};
+    $SSTICE_MESH_FILENAME = $xmlvars{'SSTICE_MESH_FILENAME'};
     $SSTICE_YEAR_ALIGN    = $xmlvars{'SSTICE_YEAR_ALIGN'};
     $SSTICE_YEAR_START    = $xmlvars{'SSTICE_YEAR_START'};
     $SSTICE_YEAR_END      = $xmlvars{'SSTICE_YEAR_END'};
@@ -927,6 +929,9 @@ if ($prognostic_mode eq 'prescribed') {
         if ($SSTICE_DATA_FILENAME eq 'UNSET') {
                 die "SSTICE_DATA_FILENAME must be set for MPAS-Seaice prescribed mode \n";
         }
+        if ($SSTICE_MESH_FILENAME eq 'UNSET') {
+                die "SSTICE_MESH_FILENAME must be set for MPAS-Seaice prescribed mode \n";
+        }
         if ($SSTICE_YEAR_ALIGN eq '-999') {
                 die "SSTICE_YEAR_ALIGN must be set for MPAS-Seaice prescribed mode \n";
         }
@@ -953,6 +958,8 @@ if ($prognostic_mode eq 'prescribed') {
         add_default($nl, 'config_prescribed_ice_model_year_align'  , 'val'=>"$SSTICE_YEAR_ALIGN");
         add_default($nl, 'config_prescribed_ice_stream_fldvarname' , 'val'=>"ice_cov");
         add_default($nl, 'config_prescribed_ice_stream_fldfilename', 'val'=>"$SSTICE_DATA_FILENAME");
+        add_default($nl, 'config_prescribed_ice_stream_meshfile'   , 'val'=>"$SSTICE_MESH_FILENAME");
+        add_default($nl, 'config_prescribed_ice_stream_mapalgo'    , 'val'=>"bilinear");
         add_default($nl, 'config_prescribed_ice_stream_domtvarname', 'val'=>"time");
         add_default($nl, 'config_prescribed_ice_stream_domxvarname', 'val'=>"$stream_domxvarname");
         add_default($nl, 'config_prescribed_ice_stream_domyvarname', 'val'=>"$stream_domyvarname");
@@ -1623,4 +1630,3 @@ sub any() {
   }
   return 0;
 }
-

--- a/bld/build-namelist-section
+++ b/bld/build-namelist-section
@@ -469,6 +469,8 @@ if ($prognostic_mode eq 'prescribed') {
         add_default($nl, 'config_prescribed_ice_model_year_align'  , 'val'=>"$SSTICE_YEAR_ALIGN");
         add_default($nl, 'config_prescribed_ice_stream_fldvarname' , 'val'=>"ice_cov");
         add_default($nl, 'config_prescribed_ice_stream_fldfilename', 'val'=>"$SSTICE_DATA_FILENAME");
+        add_default($nl, 'config_prescribed_ice_stream_meshfile'   , 'val'=>"$SSTICE_MESH_FILENAME");
+        add_default($nl, 'config_prescribed_ice_stream_mapalgo'    , 'val'=>"bilinear");
         add_default($nl, 'config_prescribed_ice_stream_domtvarname', 'val'=>"time");
         add_default($nl, 'config_prescribed_ice_stream_domxvarname', 'val'=>"$stream_domxvarname");
         add_default($nl, 'config_prescribed_ice_stream_domyvarname', 'val'=>"$stream_domyvarname");
@@ -701,4 +703,3 @@ add_default($nl, 'config_AM_timeSeriesStatsCustom_duration_intervals');
 add_default($nl, 'config_AM_timeSeriesStatsCustom_repeat_intervals');
 add_default($nl, 'config_AM_timeSeriesStatsCustom_reset_intervals');
 add_default($nl, 'config_AM_timeSeriesStatsCustom_backward_output_offset');
-

--- a/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -408,6 +408,8 @@
 <config_prescribed_ice_model_year_align>-999</config_prescribed_ice_model_year_align>
 <config_prescribed_ice_stream_fldvarname>'ice_cov'</config_prescribed_ice_stream_fldvarname>
 <config_prescribed_ice_stream_fldfilename>'unset'</config_prescribed_ice_stream_fldfilename>
+<config_prescribed_ice_stream_meshfile>'unset'</config_prescribed_ice_stream_meshfile>
+<config_prescribed_ice_stream_mapalgo>'bilinear'</config_prescribed_ice_stream_mapalgo>
 <config_prescribed_ice_stream_domtvarname>'time'</config_prescribed_ice_stream_domtvarname>
 <config_prescribed_ice_stream_domxvarname>'xc'</config_prescribed_ice_stream_domxvarname>
 <config_prescribed_ice_stream_domyvarname>'yc'</config_prescribed_ice_stream_domyvarname>

--- a/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/bld/namelist_files/namelist_definition_mpassi.xml
@@ -1,3 +1,4 @@
+dazlich@derecho4:~/ewv2.1/mpassi-pres/components/mpas-seaice> cat bld/namelist_files/namelist_definition_mpassi.xml
 <?xml version="1.0"?>
 
 <namelist_definition>
@@ -2565,6 +2566,18 @@ Default: Defined in namelist_defaults.xml
 	category="prescribed_ice" group="prescribed_ice">
 Prescribed ice stream parameter for e3sm sea ice driver.
 
+<entry id="config_prescribed_ice_stream_meshfile" type="char*1024"
+	category="prescribed_ice" group="prescribed_ice">
+Prescribed ice stream parameter for e3sm sea ice driver.
+
+Valid values: Unknown
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_prescribed_ice_stream_mapalgo" type="char*1024"
+	category="prescribed_ice" group="prescribed_ice">
+Prescribed ice stream parameter for e3sm sea ice driver.
+
 Valid values: Unknown
 Default: Defined in namelist_defaults.xml
 </entry>
@@ -3715,3 +3728,4 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 </namelist_definition>
+dazlich@derecho4:~/ewv2.1/mpassi-pres/components/mpas-seaice> 

--- a/driver_nuopc/ice_comp_nuopc.F90
+++ b/driver_nuopc/ice_comp_nuopc.F90
@@ -1,3 +1,4 @@
+dazlich@derecho4:~/ewv2.1/mpassi-pres/components/mpas-seaice> cat driver_nuopc/ice_comp_nuopc.F90
 module ice_comp_nuopc
 
   !----------------------------------------------------------------------------
@@ -17,6 +18,7 @@ module ice_comp_nuopc
   use NUOPC_Model            , only : NUOPC_ModelGet, SetVM
   use ice_import_export     , only : ice_advertise_fields, ice_realize_fields
   use ice_import_export     , only : ice_import, ice_export, ice_cpl_dt !, tlast_coupled
+  use ice_import_export     , only : ice_prescribed_init, ice_prescribed_run
   use shr_kind_mod           , only : cl=>shr_kind_cl, cs=>shr_kind_cs
   !r8 slips in through another module
   use shr_file_mod           
@@ -972,9 +974,9 @@ contains
     ! Prescribed ice initialization
     !-----------------------------------------------------------------
 
-    !DD will assume this is false for now and will implement if needed
-    !DDcall ice_prescribed_init(clock, ice_mesh, rc)
-    !DDif (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ice_prescribed_init(clock, Emesh, my_task=iam, master_task=mastertask,    &
+                             nu_diag=icelogunit,domain=domain_ptr, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !-----------------------------------------------------------------
     ! Create cice export state
@@ -1168,9 +1170,8 @@ contains
         write (WCstring,'(F18.3)') current_wallclock_time
         call mpas_log_write(trim(timeStamp) // '  WC time:' // WCstring)
 
-        !DD assumed false for now
-        !DD! get prescribed ice coverage
-        !DDcall ice_prescribed_run(domain_ptr, currTime)
+        ! get prescribed ice coverage
+        call ice_prescribed_run(domain_ptr, currTime, icelogUnit )
 
         ! pre-timestep analysis computation
         if (debugOn) call mpas_log_write('   Starting analysis precompute', masterOnly=.true.)
@@ -1561,3 +1562,4 @@ contains
 
 !***********************************************************************
 end module ice_comp_nuopc
+dazlich@derecho4:~/ewv2.1/mpassi-pres/components/mpas-seaice> 

--- a/driver_nuopc/ice_comp_nuopc.F90
+++ b/driver_nuopc/ice_comp_nuopc.F90
@@ -1,4 +1,3 @@
-dazlich@derecho4:~/ewv2.1/mpassi-pres/components/mpas-seaice> cat driver_nuopc/ice_comp_nuopc.F90
 module ice_comp_nuopc
 
   !----------------------------------------------------------------------------
@@ -1562,4 +1561,3 @@ contains
 
 !***********************************************************************
 end module ice_comp_nuopc
-dazlich@derecho4:~/ewv2.1/mpassi-pres/components/mpas-seaice> 

--- a/driver_nuopc/ice_import_export.F90
+++ b/driver_nuopc/ice_import_export.F90
@@ -1,3 +1,4 @@
+module ice_import_export
 
   use ESMF
   use NUOPC

--- a/driver_nuopc/ice_import_export.F90
+++ b/driver_nuopc/ice_import_export.F90
@@ -1,4 +1,3 @@
-module ice_import_export
 
   use ESMF
   use NUOPC
@@ -41,6 +40,10 @@ module ice_import_export
    use ice_constants_colpkg, only : Tffresh, ice_ref_salinity, p001
    use ice_colpkg, only: colpkg_sea_freezing_temperature
 
+   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_print
+   use dshr_strdata_mod , only : shr_strdata_init_from_inline, shr_strdata_advance
+   use dshr_methods_mod , only : dshr_fldbun_getfldptr
+
   implicit none
   public
 
@@ -48,6 +51,8 @@ module ice_import_export
   public  :: ice_realize_fields
   public  :: ice_import
   public  :: ice_export
+  public  :: ice_prescribed_init
+  public  :: ice_prescribed_run
 
   integer, public :: ice_cpl_dt    ! length of coupling interval in seconds - set by coupler/ESMF
 
@@ -85,6 +90,8 @@ module ice_import_export
   real(R8)    , parameter  :: czero = 0.0_R8
   character(*), parameter  :: u_FILE_u = &
        __FILE__
+
+  type(shr_strdata_type)          :: sdat           ! prescribed data stream
 
 !==============================================================================
 contains
@@ -1741,5 +1748,347 @@ contains
 !EOC
 
    end subroutine basal_pressure!}}}
+
+!***********************************************************************
+!BOP
+!
+! !IROUTINE: ice_prescribed_init
+!
+! !INTERFACE:
+  subroutine ice_prescribed_init(clock, mesh, my_task, master_task, nu_diag, domain, rc)
+!
+! !DESCRIPTION:
+! Initialize prescribed ice
+!
+! !USES:
+         
+    include 'mpif.h'
+! !INPUT/OUTPUT PARAMETERS:
+    ! input/output parameters
+    type(ESMF_Clock)       , intent(in)  :: clock
+    type(ESMF_Mesh)        , intent(in)  :: mesh
+    integer                , intent(in)  :: my_task
+    logical                , intent(in)  :: master_task
+    integer                , intent(in)  :: nu_diag
+    type (domain_type), pointer, intent(in)  :: domain
+    integer                , intent(out) :: rc
+!
+! !REVISION HISTORY:
+! Author: Adrian K. Turner
+!EOP
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+
+    integer, parameter :: nFilesMaximum = 400 ! max number of files
+
+    integer, pointer :: stream_year_first   ! first year in stream to use
+    integer, pointer :: stream_year_last    ! last year in stream to use
+    integer, pointer :: model_year_align    ! align stream_year_first
+                                   ! with this model year
+!DD    character(len=strKIND), pointer :: stream_fldVarName
+    character(len=1024), pointer :: stream_fldFileNameIn
+    character(len=1024), pointer :: stream_meshfile
+    character(len=1024), pointer :: stream_mapalgo
+    character(len=1024) :: stream_fldFileName(nFilesMaximum)
+!DD    character(len=strKIND), pointer :: stream_domTvarName
+!DD    character(len=strKIND), pointer :: stream_domXvarName
+!DD    character(len=strKIND), pointer :: stream_domYvarName
+!DD    character(len=strKIND), pointer :: stream_domAreaName
+!DD    character(len=strKIND), pointer :: stream_domMaskName
+!DD    character(len=strKIND), pointer :: stream_domFileName
+!DD    character(len=strKIND), pointer :: stream_mapread
+!DD    logical, pointer :: stream_fill ! true if data fill required
+
+    integer :: &
+         ierr, &
+         iFile, &
+         nFiles
+
+    character(len=8) :: &
+         fillalgo
+
+    character(len=16) :: &
+         inst_name
+
+    integer, pointer :: &
+         nCellsSolve
+
+    Integer :: &
+         nCells
+
+!DD    character(len=strKIND), pointer :: &
+!DD         config_calendar_type
+
+!DD    character(len=strKIND) :: &
+!DD         calendar_type
+
+    logical, pointer :: &
+         config_use_prescribed_ice
+
+    call MPAS_pool_get_config(domain % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
+    if (config_use_prescribed_ice) then
+
+       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_year_first", stream_year_first)
+       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_year_last", stream_year_last)
+       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_model_year_align", model_year_align)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_fldvarname", stream_fldVarName)
+       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_fldfilename", stream_fldFileNameIn)
+       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_meshfile", stream_meshfile)
+       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_mapalgo", stream_mapalgo)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_domtvarname", stream_domTvarName)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_domxvarname", stream_domXvarName)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_domyvarname", stream_domYvarName)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_domareaname", stream_domAreaName)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_dommaskname", stream_domMaskName)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_domfilename", stream_domFileName)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_mapread", stream_mapread)
+!DD       call mpas_pool_get_config(domain % configs, "config_prescribed_ice_stream_fill", stream_fill)
+
+       ! file array
+       stream_fldFileName(1) = trim(stream_fldFileNameIn)
+       do iFile = 2, nFilesMaximum
+          stream_fldFileName(iFile) = ' '
+       end do
+
+       ! file number
+       nFiles = 0
+       do iFile = 1, nFilesMaximum
+          if (stream_fldFileName(iFile) /= ' ') nFiles = nFiles + 1
+       end do
+
+!DD       ! Read shr_strdata_nml namelist
+!DD       if (stream_fill) then
+!DD          fillalgo='nn'
+!DD       else
+!DD          fillalgo='none'
+!DD       endif
+
+       call MPAS_log_write(' ')
+       call MPAS_log_write('This is the prescribed ice coverage option.')
+       call MPAS_log_write('  stream_year_first  = $i', intArgs=(/stream_year_first/))
+       call MPAS_log_write('  stream_year_last   = $i', intArgs=(/stream_year_last/))
+       call MPAS_log_write('  model_year_align   = $i', intArgs=(/model_year_align/))
+       call MPAS_log_write('  stream_meshfile = '//trim(stream_meshfile) )
+!DD       call MPAS_log_write('  stream_fldVarName  = '//trim(stream_fldVarName))
+       do iFile = 1, nFiles
+          call MPAS_log_write('  stream_fldFileName = $i: '//trim(stream_fldFileName(iFile)), intArgs=(/iFile/))
+       end do
+!DD       call MPAS_log_write('  stream_domTvarName = '//trim(stream_domTvarName))
+!DD       call MPAS_log_write('  stream_domXvarName = '//trim(stream_domXvarName))
+!DD       call MPAS_log_write('  stream_domYvarName = '//trim(stream_domYvarName))
+!DD       call MPAS_log_write('  stream_domFileName = '//trim(stream_domFileName))
+!DD       call MPAS_log_write('  stream_domAreaName = '//trim(stream_domAreaName))
+!DD       call MPAS_log_write('  stream_domMaskName = '//trim(stream_domMaskName))
+!DD       call MPAS_log_write('  stream_mapread     = '//trim(stream_mapread))
+!DD       call MPAS_log_write('  stream_fillalgo    = '//trim(fillalgo))
+       call MPAS_log_write('  stream_mapalso = '//trim(stream_mapalgo) )
+       call MPAS_log_write(' ')
+
+!DD       inst_name = seq_comm_name(compid)
+
+       call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nCellsSolve", nCellsSolve)
+       call MPI_Allreduce(nCellsSolve, nCells, 1, MPI_Integer, MPI_SUM, domain % dminfo % comm, ierr)
+       
+
+!DD       call MPAS_pool_get_config(domain % configs, "config_calendar_type", config_calendar_type)
+!DD       if (trim(config_calendar_type) == "gregorian") then
+!DD          calendar_type = shr_cal_gregorian
+!DD       else if (trim(config_calendar_type) == "gregorian_noleap") then
+!DD          calendar_type = shr_cal_noleap
+!DD       else
+!DD          call MPAS_log_write("ice_prescribed_init: Unknown calendar type: "//trim(config_calendar_type))
+!DD       endif
+
+!DD--- translate mct to nuopc
+
+!DD--- begin old code
+!DD       call shr_strdata_create( &
+!DD            sdat, &
+!DD            name = "prescribed_ice", &
+!DD            mpicom = domain % dminfo % comm, &
+!DD            compid = compid, &
+!DD            gsmap = gsmap, &
+!DD            ggrid = dom, &
+!DD            nxg = nCells, &
+!DD            nyg = 1, &
+!DD            yearFirst = stream_year_first, &
+!DD            yearLast = stream_year_last, &
+!DD            yearAlign = model_year_align, &
+!DD            offset = 0, &
+!DD            domFilePath = '', &
+!DD            domFileName = trim(stream_domFileName), &
+!DD            domTvarName = trim(stream_domTvarName), &
+!DD            domXvarName = trim(stream_domXvarName), &
+!DD            domYvarName = trim(stream_domYvarName), &
+!DD            domAreaName = trim(stream_domAreaName), &
+!DD            domMaskName = trim(stream_domMaskName), &
+!DD            filePath = '', &
+!DD            filename = stream_fldFileName(1:nFiles), &
+!DD            fldListFile = trim(stream_fldVarName), &
+!DD            fldListModel = trim(stream_fldVarName), &
+!DD            pio_subsystem = shr_pio_getiosys(inst_name), &
+!DD            pio_iotype = shr_pio_getiotype(inst_name), &
+!DD            fillalgo = trim(fillalgo), &
+!DD            calendar = trim(calendar_type), &
+!DD            mapread = trim(stream_mapread))
+
+!DD--- begin new code
+
+       ! initialize sdat
+       call shr_strdata_init_from_inline(sdat,               &
+            my_task             = my_task,                   &
+            logunit             = nu_diag,                   &
+            compname            = 'ICE',                     &
+            model_clock         = clock,                     &
+            model_mesh          = mesh,                      &
+            stream_meshfile     = stream_meshfile,           &
+            stream_lev_dimname  = 'null',                    &
+            stream_mapalgo      = trim(stream_mapalgo),      &
+            stream_filenames    = stream_fldFileName(1:nfiles), &
+            stream_fldlistFile  = (/'ice_cov'/),             &
+            stream_fldListModel = (/'ice_cov'/),             &
+            stream_yearFirst    = stream_year_First,          &
+            stream_yearLast     = stream_year_Last,           &
+            stream_yearAlign    = model_year_Align ,         &
+            stream_offset       = 0,                         &
+            stream_taxmode      = 'cycle',                   &
+            stream_dtlimit      = 1.5_dbl_kind,              &
+            stream_tintalgo     = 'linear',                  &
+            rc                  = rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       ! print out sdat info
+       if (master_task) then
+          call shr_strdata_print(sdat,'ice coverage prescribed data')
+       endif
+
+!DD--- end translation
+
+    endif ! config_use_prescribed_ice
+
+  end subroutine ice_prescribed_init
+
+!***********************************************************************
+!BOP
+!
+! !IROUTINE: ice_prescribed_run
+!
+! !INTERFACE:
+  subroutine ice_prescribed_run( domain, currTime, nu_diag )!{{{
+!
+! !DESCRIPTION:
+! Set ice coverage for prescribed ice mode
+!
+! !USES:
+! !INPUT/OUTPUT PARAMETERS:
+    type (domain_type), pointer :: &
+         domain
+    type (MPAS_Time_Type), intent(in) :: &
+         currTime
+    integer                , intent(in)  :: nu_diag
+!
+! !REVISION HISTORY:
+! Author: Adrian K. Turner
+!EOP
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+
+    real(kind=dbl_kind), pointer :: dataptr(:)
+
+    logical, pointer :: &
+         config_use_prescribed_ice
+
+    integer :: &
+         mDateIn, &
+         secIn, &
+         YYYY, MM, DD, DoY, H, M, S, &
+         ierr
+
+    integer :: &
+         n, &
+         iCell, &
+         rc
+
+    type (block_type), pointer :: &
+         block_ptr
+
+    type (mpas_pool_type), pointer :: &
+         meshPool, &
+         prescribedIcePool
+
+    integer, pointer :: &
+         nCellsSolve
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         iceCoverage
+
+    type (field1DReal), pointer :: &
+         iceCoverageField
+    
+    call MPAS_pool_get_config(domain % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
+    if (config_use_prescribed_ice) then
+
+       call MPAS_get_time(currTime, YYYY, MM, DD, DoY, H, M, S, ierr)
+       mDateIn = YYYY * 10000 + MM * 100 + DD
+       secIn = H * 3600 + M * 60 + S
+
+!DD--- translate mct to nuopc
+
+!DD--- old code
+!DD       call shr_strdata_advance(&
+!DD            sdat, &
+!DD            mDateIn, &
+!DD            SecIn, &
+!DD            domain % dminfo % comm, &
+!DD            'mpassi_pice')
+
+!DD--- newcode
+       call shr_strdata_advance(sdat, ymd=mDateIn, tod=SecIn, logunit=nu_diag, istr='cice_pice', rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+          call ESMF_Finalize(endflag=ESMF_END_ABORT)
+       end if
+
+       ! Get pointer for stream data that is time and spatially interpolate to model time and grid
+       call dshr_fldbun_getFldPtr(sdat%pstrm(1)%fldbun_model, 'ice_cov', dataptr, rc=rc)
+       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) then
+          call ESMF_Finalize(endflag=ESMF_END_ABORT)
+       end if
+!DD--- end translation
+
+       n = 0
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+
+          call MPAS_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+          call MPAS_pool_get_subpool(block_ptr % structs, 'prescribed_ice', prescribedIcePool)
+
+          call MPAS_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+          call MPAS_pool_get_array(prescribedIcePool, 'iceCoverage', iceCoverage)
+
+          iceCoverage(:) = 0.0_RKIND
+
+          do iCell = 1, nCellsSolve
+             n = n + 1
+!DD             iceCoverage(iCell) = sdat % avs(1) % rAttr(1,n)
+             iceCoverage(iCell) = dataptr(n)
+          enddo ! iCell
+
+          block_ptr => block_ptr % next
+       end do
+
+       call MPAS_pool_get_subpool(domain % blocklist % structs, 'prescribed_ice', prescribedIcePool)
+       call MPAS_pool_get_field(prescribedIcePool, 'iceCoverage', iceCoverageField)
+       call MPAS_dmpar_exch_halo_field(iceCoverageField)
+
+    endif
+
+  end subroutine ice_prescribed_run
 
 end module ice_import_export

--- a/src/Registry.xml
+++ b/src/Registry.xml
@@ -1805,6 +1805,14 @@
 			description="Prescribed ice stream parameter for e3sm sea ice driver."
 			possible_values="Unknown"
 		/>
+		<nml_option name="config_prescribed_ice_stream_meshfile" type="character" default_value="unset" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="config_prescribed_ice_stream_mapalgo" type="character" default_value="unset" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
 		<nml_option name="config_prescribed_ice_stream_domtvarname" type="character" default_value="time" units="unitless"
 			description="Prescribed ice stream parameter for e3sm sea ice driver."
 			possible_values="Unknown"
@@ -2515,7 +2523,7 @@
 		<var name="verticalSalinity"			type="real"	dimensions="nBioLayers nCategories nCells Time"		name_in_code="verticalSalinity"		packages="pkgTracerZSalinity"/>
 	</var_struct>
 	<var_struct name="tracers_aggregate" time_levs="1">
-		<var name="iceAreaCell"			type="real"	dimensions="nCells Time"			name_in_code="iceAreaCell"/>
+		<var name="iceAreaCell"			type="real"	dimensions="nCells Time"	name_in_code="iceAreaCell"/>
 		<var name="iceVolumeCell"			type="real"	dimensions="nCells Time"			name_in_code="iceVolumeCell"/>
 		<var name="snowVolumeCell"			type="real"	dimensions="nCells Time"			name_in_code="snowVolumeCell"/>
 		<var name="surfaceTemperatureCell"		type="real"	dimensions="nCells Time"			name_in_code="surfaceTemperatureCell"/>
@@ -2566,10 +2574,10 @@
 		<var name="skeletalNitrateConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalNitrateConcCell"		packages="pkgTracerSkeletalNitrate"/>
 		<var name="skeletalSilicateConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalSilicateConcCell"	packages="pkgTracerSkeletalSilicate"/>
 		<var name="skeletalAmmoniumConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalAmmoniumConcCell"	packages="pkgTracerSkeletalAmmonium"/>
-		<var name="skeletalDMSConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalDMSConcCell"		packages="pkgTracerSkeletalDMS"/>
+		<var name="skeletalDMSConcCell"		type="real"	dimensions="ONE nCells Timename_in_code="skeletalDMSConcCell"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPpConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalDMSPpConcCell"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPdConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalDMSPdConcCell"		packages="pkgTracerSkeletalDMS"/>
-		<var name="skeletalNonreactiveConcCell"	type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalNonreactiveConcCell"	packages="pkgTracerSkeletalNonreactive"/>
+		<var name="skeletalNonreactiveConcCell"	type="real"	dimensions="ONE nCells Timename_in_code="skeletalNonreactiveConcCell"	packages="pkgTracerSkeletalNonreactive"/>
 		<var name="skeletalHumicsConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalHumicsConcCell"		packages="pkgTracerSkeletalHumics"/>
 		<var name="skeletalParticulateIronConcCell"	type="real"	dimensions="nParticulateIron nCells Time"	name_in_code="skeletalParticulateIronConcCell"	packages="pkgTracerSkeletalIron"/>
 		<var name="skeletalDissolvedIronConcCell"	type="real"	dimensions="nDissolvedIron nCells Time"	name_in_code="skeletalDissolvedIronConcCell"	packages="pkgTracerSkeletalIron"/>
@@ -2594,10 +2602,10 @@
 		<var name="verticalNitrateSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalNitrateSnowCell"		packages="pkgTracerVerticalNitrate"/>
 		<var name="verticalSilicateSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalSilicateSnowCell"	packages="pkgTracerVerticalSilicate"/>
 		<var name="verticalAmmoniumSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalAmmoniumSnowCell"	packages="pkgTracerVerticalAmmonium"/>
-		<var name="verticalDMSSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalDMSSnowCell"		packages="pkgTracerVerticalDMS"/>
+		<var name="verticalDMSSnowCell"		type="real"	dimensions="TWO nCells Timename_in_code="verticalDMSSnowCell"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPpSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalDMSPpSnowCell"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPdSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalDMSPdSnowCell"		packages="pkgTracerVerticalDMS"/>
-		<var name="verticalNonreactiveSnowCell"	type="real"	dimensions="TWO nCells Time"			name_in_code="verticalNonreactiveSnowCell"	packages="pkgTracerVerticalNonreactive"/>
+		<var name="verticalNonreactiveSnowCell"	type="real"	dimensions="TWO nCells Timename_in_code="verticalNonreactiveSnowCell"	packages="pkgTracerVerticalNonreactive"/>
 		<var name="verticalHumicsSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalHumicsSnowCell"		packages="pkgTracerVerticalHumics"/>
 		<var name="verticalParticulateIronSnowCell"	type="real"	dimensions="nPartIronSnowLayers nCells Time"	name_in_code="verticalParticulateIronSnowCell"	packages="pkgTracerVerticalIron"/>
 		<var name="verticalDissolvedIronSnowCell"	type="real"	dimensions="nDisIronSnowLayers nCells Time"	name_in_code="verticalDissolvedIronSnowCell"	packages="pkgTracerVerticalIron"/>
@@ -2928,10 +2936,10 @@
 		<var name="iceEnthalpyTriangle"			type="real"	dimensions="nIceLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="iceEnthalpyTriangle"/>
 		<var name="iceSalinityTriangle"			type="real"	dimensions="nIceLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="iceSalinityTriangle"/>
 		<var name="snowEnthalpyTriangle"			type="real"	dimensions="nSnowLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="snowEnthalpyTriangle"/>
-		<var name="snowIceMassTriangle"			type="real"	dimensions="nSnowLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="snowIceMassTriangle"			packages="pkgColumnTracerEffectiveSnowDensity"/>
+		<var name="snowIceMassTriangle"			type="real"	dimensions="nSnowLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="snowIceMassTriangle"	packages="pkgColumnTracerEffectiveSnowDensity"/>
 		<var name="snowLiquidMassTriangle"			type="real"	dimensions="nSnowLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="snowLiquidMassTriangle"			packages="pkgColumnTracerEffectiveSnowDensity"/>
 		<var name="snowGrainRadiusTriangle"			type="real"	dimensions="nSnowLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="snowGrainRadiusTriangle"			packages="pkgColumnTracerSnowGrainRadius"/>
-		<var name="snowDensityTriangle"			type="real"	dimensions="nSnowLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="snowDensityTriangle"			packages="pkgColumnTracerEffectiveSnowDensity"/>
+		<var name="snowDensityTriangle"			type="real"	dimensions="nSnowLayers nCategories nQuadPoints nTriPerEdgeRemap nEdges"		name_in_code="snowDensityTriangle"	packages="pkgColumnTracerEffectiveSnowDensity"/>
 		<var name="iceAgeTriangle"				type="real"	dimensions="ONE nCategories nQuadPoints nTriPerEdgeRemap nEdges"			name_in_code="iceAgeTriangle"				packages="pkgColumnTracerIceAge"/>
 		<var name="firstYearIceAreaTriangle"			type="real"	dimensions="ONE nCategories nQuadPoints nTriPerEdgeRemap nEdges"			name_in_code="firstYearIceAreaTriangle"		packages="pkgColumnTracerFirstYearIce"/>
 		<var name="levelIceAreaTriangle"			type="real"	dimensions="ONE nCategories nQuadPoints nTriPerEdgeRemap nEdges"			name_in_code="levelIceAreaTriangle"			packages="pkgColumnTracerLevelIce"/>
@@ -3003,7 +3011,7 @@
 		<var name="iceEnthalpyBarycenterx"			type="real"	dimensions="nIceLayers nCategories nCells"		name_in_code="iceEnthalpyBarycenterx"/>
 		<var name="iceEnthalpyBarycentery"			type="real"	dimensions="nIceLayers nCategories nCells"		name_in_code="iceEnthalpyBarycentery"/>
 		<var name="iceSalinityBarycenterx"			type="real"	dimensions="nIceLayers nCategories nCells"		name_in_code="iceSalinityBarycenterx"/>
-		<var name="iceSalinityBarycentery"			type="real"	dimensions="nIceLayers nCategories nCells"		name_in_code="iceSalinityBarycentery"/>
+		<var name="iceSalinityBarycentery"			type="real"	dimensions="nIceLayers nCategories nCells"			name_in_code="iceSalinityBarycentery"/>
 		<var name="snowEnthalpyBarycenterx"			type="real"	dimensions="nSnowLayers nCategories nCells"		name_in_code="snowEnthalpyBarycenterx"/>
 		<var name="snowEnthalpyBarycentery"			type="real"	dimensions="nSnowLayers nCategories nCells"		name_in_code="snowEnthalpyBarycentery"/>
 		<var name="snowIceMassBarycenterx"			type="real"	dimensions="nSnowLayers nCategories nCells"		name_in_code="snowIceMassBarycenterx"			packages="pkgColumnTracerEffectiveSnowDensity"/>
@@ -3066,8 +3074,8 @@
 		<var name="skeletalHumicsConcBarycentery"		type="real"	dimensions="ONE nCategories nCells"			name_in_code="skeletalHumicsConcBarycentery"		packages="pkgTracerSkeletalHumics"/>
 		<var name="skeletalParticulateIronConcBarycenterx"	type="real"	dimensions="nParticulateIron nCategories nCells"	name_in_code="skeletalParticulateIronConcBarycenterx"	packages="pkgTracerSkeletalIron"/>
 		<var name="skeletalParticulateIronConcBarycentery"	type="real"	dimensions="nParticulateIron nCategories nCells"	name_in_code="skeletalParticulateIronConcBarycentery"	packages="pkgTracerSkeletalIron"/>
-		<var name="skeletalDissolvedIronConcBarycenterx"	type="real"	dimensions="nDissolvedIron nCategories nCells"		name_in_code="skeletalDissolvedIronConcBarycenterx"	packages="pkgTracerSkeletalIron"/>
-		<var name="skeletalDissolvedIronConcBarycentery"	type="real"	dimensions="nDissolvedIron nCategories nCells"		name_in_code="skeletalDissolvedIronConcBarycentery"	packages="pkgTracerSkeletalIron"/>
+		<var name="skeletalDissolvedIronConcBarycenterx"	type="real"	dimensions="nDissolvedIron nCategories nCells"		name_in_code="skeletalDissolvedIronConcBarycenterx"packages="pkgTracerSkeletalIron"/>
+		<var name="skeletalDissolvedIronConcBarycentery"	type="real"	dimensions="nDissolvedIron nCategories nCells"		name_in_code="skeletalDissolvedIronConcBarycentery"packages="pkgTracerSkeletalIron"/>
 		<var name="verticalAlgaeSnowBarycenterx"		type="real"	dimensions="nAlgaeSnowLayers nCategories nCells"	name_in_code="verticalAlgaeSnowBarycenterx"		packages="pkgTracerVerticalAlgae"/>
 		<var name="verticalAlgaeSnowBarycentery"		type="real"	dimensions="nAlgaeSnowLayers nCategories nCells"	name_in_code="verticalAlgaeSnowBarycentery"		packages="pkgTracerVerticalAlgae"/>
 		<var name="verticalDOCSnowBarycenterx"			type="real"	dimensions="nDOCSnowLayers nCategories nCells"		name_in_code="verticalDOCSnowBarycenterx"		packages="pkgTracerVerticalCarbon"/>
@@ -3341,7 +3349,7 @@
 		<var name="verticalSalinityGrady"		type="real"	dimensions="nBioLayers nCategories nCells"		name_in_code="verticalSalinityGrady"			packages="pkgTracerZSalinity"/>
 	</var_struct>
 	<var_struct name="tracer_conservation" time_levs="2">
-		<var name="iceAreaCategoryCons"		type="real"	dimensions="ONE nCategories"				name_in_code="iceAreaCategoryCons"/>
+		<var name="iceAreaCategoryCons"		type="real"	dimensions="ONE nCategoriesname_in_code="iceAreaCategoryCons"/>
 		<var name="iceVolumeCategoryCons"		type="real"	dimensions="ONE nCategories"				name_in_code="iceVolumeCategoryCons"/>
 		<var name="snowVolumeCategoryCons"		type="real"	dimensions="ONE nCategories"				name_in_code="snowVolumeCategoryCons"/>
 		<var name="surfaceTemperatureCons"		type="real"	dimensions="ONE nCategories"				name_in_code="surfaceTemperatureCons"/>
@@ -3372,10 +3380,10 @@
 		<var name="skeletalNitrateConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalNitrateConcCons"		packages="pkgTracerSkeletalNitrate"/>
 		<var name="skeletalSilicateConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalSilicateConcCons"	packages="pkgTracerSkeletalSilicate"/>
 		<var name="skeletalAmmoniumConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalAmmoniumConcCons"	packages="pkgTracerSkeletalAmmonium"/>
-		<var name="skeletalDMSConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalDMSConcCons"		packages="pkgTracerSkeletalDMS"/>
+		<var name="skeletalDMSConcCons"		type="real"	dimensions="ONE nCategoriesname_in_code="skeletalDMSConcCons"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPpConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalDMSPpConcCons"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPdConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalDMSPdConcCons"		packages="pkgTracerSkeletalDMS"/>
-		<var name="skeletalNonreactiveConcCons"	type="real"	dimensions="ONE nCategories"				name_in_code="skeletalNonreactiveConcCons"	packages="pkgTracerSkeletalNonreactive"/>
+		<var name="skeletalNonreactiveConcCons"	type="real"	dimensions="ONE nCategoriesname_in_code="skeletalNonreactiveConcCons"	packages="pkgTracerSkeletalNonreactive"/>
 		<var name="skeletalHumicsConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalHumicsConcCons"		packages="pkgTracerSkeletalHumics"/>
 		<var name="skeletalParticulateIronConcCons"	type="real"	dimensions="nParticulateIron nCategories"		name_in_code="skeletalParticulateIronConcCons"	packages="pkgTracerSkeletalIron"/>
 		<var name="skeletalDissolvedIronConcCons"	type="real"	dimensions="nDissolvedIron nCategories"		name_in_code="skeletalDissolvedIronConcCons"	packages="pkgTracerSkeletalIron"/>
@@ -3386,10 +3394,10 @@
 		<var name="verticalNitrateSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalNitrateSnowCons"		packages="pkgTracerVerticalNitrate"/>
 		<var name="verticalSilicateSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalSilicateSnowCons"	packages="pkgTracerVerticalSilicate"/>
 		<var name="verticalAmmoniumSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalAmmoniumSnowCons"	packages="pkgTracerVerticalAmmonium"/>
-		<var name="verticalDMSSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalDMSSnowCons"		packages="pkgTracerVerticalDMS"/>
+		<var name="verticalDMSSnowCons"		type="real"	dimensions="TWO nCategoriesname_in_code="verticalDMSSnowCons"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPpSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalDMSPpSnowCons"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPdSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalDMSPdSnowCons"		packages="pkgTracerVerticalDMS"/>
-		<var name="verticalNonreactiveSnowCons"	type="real"	dimensions="TWO nCategories"				name_in_code="verticalNonreactiveSnowCons"	packages="pkgTracerVerticalNonreactive"/>
+		<var name="verticalNonreactiveSnowCons"	type="real"	dimensions="TWO nCategoriesname_in_code="verticalNonreactiveSnowCons"	packages="pkgTracerVerticalNonreactive"/>
 		<var name="verticalHumicsSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalHumicsSnowCons"		packages="pkgTracerVerticalHumics"/>
 		<var name="verticalParticulateIronSnowCons"	type="real"	dimensions="nPartIronSnowLayers nCategories"		name_in_code="verticalParticulateIronSnowCons"	packages="pkgTracerVerticalIron"/>
 		<var name="verticalDissolvedIronSnowCons"	type="real"	dimensions="nDisIronSnowLayers nCategories"		name_in_code="verticalDissolvedIronSnowCons"	packages="pkgTracerVerticalIron"/>
@@ -3553,15 +3561,15 @@
 	</var_struct>
 
 	<var_struct name="rotated_mesh" time_levs="1">
-		<var name="xCellRotate"			type="real"	dimensions="nCells"				name_in_code="xCellRotate"/>
-		<var name="yCellRotate"			type="real"	dimensions="nCells"				name_in_code="yCellRotate"/>
-		<var name="zCellRotate"			type="real"	dimensions="nCells"				name_in_code="zCellRotate"/>
+		<var name="xCellRotate"			type="real"	dimensions="nCells"		name_in_code="xCellRotate"/>
+		<var name="yCellRotate"			type="real"	dimensions="nCells"		name_in_code="yCellRotate"/>
+		<var name="zCellRotate"			type="real"	dimensions="nCells"		name_in_code="zCellRotate"/>
 		<var name="xVertexRotate"			type="real"	dimensions="nVertices"				name_in_code="xVertexRotate"/>
 		<var name="yVertexRotate"			type="real"	dimensions="nVertices"				name_in_code="yVertexRotate"/>
 		<var name="zVertexRotate"			type="real"	dimensions="nVertices"				name_in_code="zVertexRotate"/>
-		<var name="xEdgeRotate"			type="real"	dimensions="nEdges"				name_in_code="xEdgeRotate"/>
-		<var name="yEdgeRotate"			type="real"	dimensions="nEdges"				name_in_code="yEdgeRotate"/>
-		<var name="zEdgeRotate"			type="real"	dimensions="nEdges"				name_in_code="zEdgeRotate"/>
+		<var name="xEdgeRotate"			type="real"	dimensions="nEdges"		name_in_code="xEdgeRotate"/>
+		<var name="yEdgeRotate"			type="real"	dimensions="nEdges"		name_in_code="yEdgeRotate"/>
+		<var name="zEdgeRotate"			type="real"	dimensions="nEdges"		name_in_code="zEdgeRotate"/>
 	</var_struct>
 
 	<!-- incremental remapping -->
@@ -3571,7 +3579,7 @@
 		<var name="iCellTriangle"			type="integer"	dimensions="nTriPerEdgeRemap nEdges"			name_in_code="iCellTriangle"/>
 		<var name="triangleArea"			type="real"	dimensions="nTriPerEdgeRemap nEdges"			name_in_code="triangleArea"/>
 		<var name="departurePoint"			type="real"	dimensions="TWO nVertices"				name_in_code="departurePoint"/>
-		<var name="remapEdge"				type="integer"	dimensions="nEdges"					name_in_code="remapEdge"/>
+		<var name="remapEdge"				type="integer"	dimensions="nEdges"name_in_code="remapEdge"/>
 		<var name="cellsOnEdgeRemap"			type="integer"	dimensions="maxCellsPerEdgeRemap nEdges"		name_in_code="cellsOnEdgeRemap"/>
 		<var name="edgesOnEdgeRemap"			type="integer"	dimensions="maxEdgesPerEdgeRemap nEdges"		name_in_code="edgesOnEdgeRemap"/>
 		<var name="xVertexOnCell"			type="real"	dimensions="maxEdges nCells"				name_in_code="xVertexOnCell"/>
@@ -3580,27 +3588,27 @@
 		<var name="yVertexOnEdge"			type="real"	dimensions="maxVerticesPerEdgeRemap nEdges"		name_in_code="yVertexOnEdge"/>
 		<var name="transCellToGlobal"			type="real"	dimensions="R3 R3 nCells"				name_in_code="transCellToGlobal"/>
 		<var name="transGlobalToCell"			type="real"	dimensions="R3 R3 nCells"				name_in_code="transGlobalToCell"/>
-		<var name="transVertexToGlobal"		type="real"	dimensions="R3 R3 nVertices"				name_in_code="transVertexToGlobal"/>
-		<var name="transGlobalToVertex"		type="real"	dimensions="R3 R3 nVertices"				name_in_code="transGlobalToVertex"/>
+		<var name="transVertexToGlobal"		type="real"	dimensions="R3 R3 nVerticesname_in_code="transVertexToGlobal"/>
+		<var name="transGlobalToVertex"		type="real"	dimensions="R3 R3 nVerticesname_in_code="transGlobalToVertex"/>
 		<var name="transEdgeToGlobal"			type="real"	dimensions="R3 R3 nEdges"				name_in_code="transEdgeToGlobal"/>
 		<var name="transGlobalToEdge"			type="real"	dimensions="R3 R3 nEdges"				name_in_code="transGlobalToEdge"/>
 		<var name="minLengthEdgesOnVertex"		type="real"	dimensions="nVertices"					name_in_code="minLengthEdgesOnVertex"/>
-		<var name="xAvgCell"				type="real"	dimensions="nCells"					name_in_code="xAvgCell"/>
-		<var name="yAvgCell"				type="real"	dimensions="nCells"					name_in_code="yAvgCell"/>
-		<var name="xxAvgCell"				type="real"	dimensions="nCells"					name_in_code="xxAvgCell"/>
-		<var name="xyAvgCell"				type="real"	dimensions="nCells"					name_in_code="xyAvgCell"/>
-		<var name="yyAvgCell"				type="real"	dimensions="nCells"					name_in_code="yyAvgCell"/>
-		<var name="xxxAvgCell"				type="real"	dimensions="nCells"					name_in_code="xxxAvgCell"/>
-		<var name="xxyAvgCell"				type="real"	dimensions="nCells"					name_in_code="xxyAvgCell"/>
-		<var name="xyyAvgCell"				type="real"	dimensions="nCells"					name_in_code="xyyAvgCell"/>
-		<var name="yyyAvgCell"				type="real"	dimensions="nCells"					name_in_code="yyyAvgCell"/>
-		<var name="xxxxAvgCell"			type="real"	dimensions="nCells"					name_in_code="xxxxAvgCell"/>
-		<var name="xxxyAvgCell"			type="real"	dimensions="nCells"					name_in_code="xxxyAvgCell"/>
-		<var name="xxyyAvgCell"			type="real"	dimensions="nCells"					name_in_code="xxyyAvgCell"/>
-		<var name="xyyyAvgCell"			type="real"	dimensions="nCells"					name_in_code="xyyyAvgCell"/>
-		<var name="yyyyAvgCell"			type="real"	dimensions="nCells"					name_in_code="yyyyAvgCell"/>
-		<var name="maskEdge"				type="integer"	dimensions="nEdges"					name_in_code="maskEdge"/>
-		<var name="maskCell"				type="integer"	dimensions="nCells"					name_in_code="maskCell"/>
+		<var name="xAvgCell"				type="real"	dimensions="nCells"name_in_code="xAvgCell"/>
+		<var name="yAvgCell"				type="real"	dimensions="nCells"name_in_code="yAvgCell"/>
+		<var name="xxAvgCell"				type="real"	dimensions="nCells"name_in_code="xxAvgCell"/>
+		<var name="xyAvgCell"				type="real"	dimensions="nCells"name_in_code="xyAvgCell"/>
+		<var name="yyAvgCell"				type="real"	dimensions="nCells"name_in_code="yyAvgCell"/>
+		<var name="xxxAvgCell"				type="real"	dimensions="nCells"name_in_code="xxxAvgCell"/>
+		<var name="xxyAvgCell"				type="real"	dimensions="nCells"name_in_code="xxyAvgCell"/>
+		<var name="xyyAvgCell"				type="real"	dimensions="nCells"name_in_code="xyyAvgCell"/>
+		<var name="yyyAvgCell"				type="real"	dimensions="nCells"name_in_code="yyyAvgCell"/>
+		<var name="xxxxAvgCell"			type="real"	dimensions="nCells"		name_in_code="xxxxAvgCell"/>
+		<var name="xxxyAvgCell"			type="real"	dimensions="nCells"		name_in_code="xxxyAvgCell"/>
+		<var name="xxyyAvgCell"			type="real"	dimensions="nCells"		name_in_code="xxyyAvgCell"/>
+		<var name="xyyyAvgCell"			type="real"	dimensions="nCells"		name_in_code="xyyyAvgCell"/>
+		<var name="yyyyAvgCell"			type="real"	dimensions="nCells"		name_in_code="yyyyAvgCell"/>
+		<var name="maskEdge"				type="integer"	dimensions="nEdges"name_in_code="maskEdge"/>
+		<var name="maskCell"				type="integer"	dimensions="nCells"name_in_code="maskCell"/>
 		<var name="maskCategoryCell"			type="integer"	dimensions="nCategories nCells"			name_in_code="maskCategoryCell"/>
 		<var name="workCategoryCell"			type="real"	dimensions="nCategories nCells"			name_in_code="workCategoryCell"/>
 	</var_struct>
@@ -3617,10 +3625,10 @@
 		<var name="airLevelHeight"			type="real"	dimensions="nCells Time"		name_in_code="airLevelHeight"			default_value="10.0"/>
 		<var name="airPotentialTemperature"		type="real"	dimensions="nCells Time"		name_in_code="airPotentialTemperature"		default_value="253.0"/>
 		<var name="airTemperature"			type="real"	dimensions="nCells Time"		name_in_code="airTemperature"			default_value="253.0"/>
-		<var name="airSpecificHumidity"		type="real"	dimensions="nCells Time"		name_in_code="airSpecificHumidity"		default_value="0.0006"/>
+		<var name="airSpecificHumidity"		type="real"	dimensions="nCells Time"	name_in_code="airSpecificHumidity"		default_value="0.0006"/>
 		<var name="airDensity"				type="real"	dimensions="nCells Time"		name_in_code="airDensity"			default_value="1.3"/>
 		<var name="shortwaveVisibleDirectDown"		type="real"	dimensions="nCells Time"		name_in_code="shortwaveVisibleDirectDown"/>
-		<var name="shortwaveVisibleDiffuseDown"	type="real"	dimensions="nCells Time"		name_in_code="shortwaveVisibleDiffuseDown"/>
+		<var name="shortwaveVisibleDiffuseDown"	type="real"	dimensions="nCells Time"	name_in_code="shortwaveVisibleDiffuseDown"/>
 		<var name="shortwaveIRDirectDown"		type="real"	dimensions="nCells Time"		name_in_code="shortwaveIRDirectDown"/>
 		<var name="shortwaveIRDiffuseDown"		type="real"	dimensions="nCells Time"		name_in_code="shortwaveIRDiffuseDown"/>
 		<var name="longwaveDown"			type="real"	dimensions="nCells Time"		name_in_code="longwaveDown"			default_value="180.0"/>
@@ -3629,7 +3637,7 @@
 		<var name="uAirVelocity"			type="real"	dimensions="nCells Time"		name_in_code="uAirVelocity"			default_value="5.0"/>
 		<var name="vAirVelocity"			type="real"	dimensions="nCells Time"		name_in_code="vAirVelocity"			default_value="5.0"/>
 		<var name="atmosReferenceSpeed10m"		type="real"	dimensions="nCells Time"		name_in_code="atmosReferenceSpeed10m"/>
-		<var name="atmosReferenceTemperature2m"	type="real"	dimensions="nCells Time"		name_in_code="atmosReferenceTemperature2m"/>
+		<var name="atmosReferenceTemperature2m"	type="real"	dimensions="nCells Time"	name_in_code="atmosReferenceTemperature2m"/>
 		<var name="atmosReferenceHumidity2m"		type="real"	dimensions="nCells Time"		name_in_code="atmosReferenceHumidity2m"/>
 	</var_struct>
 
@@ -3640,7 +3648,7 @@
 		<var name="vAirStress"				type="real"	dimensions="nCells Time"		name_in_code="vAirStress"			default_value="0.05"/>
 		<var name="shortwaveDown"			type="real"	dimensions="nCells Time"		name_in_code="shortwaveDown"/>
 		<var name="cloudFraction"			type="real"	dimensions="nCells Time"		name_in_code="cloudFraction"/>
-		<var name="sensibleTransferCoefficient"	type="real"	dimensions="nCells Time"		name_in_code="sensibleTransferCoefficient"/>
+		<var name="sensibleTransferCoefficient"	type="real"	dimensions="nCells Time"	name_in_code="sensibleTransferCoefficient"/>
 		<var name="latentTransferCoefficient"		type="real"	dimensions="nCells Time"		name_in_code="latentTransferCoefficient"/>
 	</var_struct>
 
@@ -3667,7 +3675,7 @@
 		<var name="seaSurfaceTiltV"			type="real"	dimensions="nCells Time"		name_in_code="seaSurfaceTiltV"/>
 		<var name="oceanMixedLayerDepth"		type="real"	dimensions="nCells Time"		name_in_code="oceanMixedLayerDepth"		default_value="20.0"/>
 		<var name="oceanHeatFluxConvergence"		type="real"	dimensions="nCells Time"		name_in_code="oceanHeatFluxConvergence"/>
-		<var name="landIceMask"			type="integer"	dimensions="nCells Time"		name_in_code="landIceMask"/>
+		<var name="landIceMask"			type="integer"	dimensions="nCells Time"	name_in_code="landIceMask"/>
 		<var name="landIceMaskVertex"			type="integer"	dimensions="nVertices Time"		name_in_code="landIceMaskVertex"/>
 	</var_struct>
 
@@ -3681,8 +3689,8 @@
 
 	<!-- velocity solver -->
 	<var_struct name="velocity_solver" time_levs="1">
-		<var name="dynamicsTimeStep"			type="real"	dimensions=""				name_in_code="dynamicsTimeStep"/>
-		<var name="elasticTimeStep"			type="real"	dimensions=""				name_in_code="elasticTimeStep"/>
+		<var name="dynamicsTimeStep"			type="real"	dimensions=""		name_in_code="dynamicsTimeStep"/>
+		<var name="elasticTimeStep"			type="real"	dimensions=""		name_in_code="elasticTimeStep"/>
 		<var name="uVelocity"				type="real"	dimensions="nVertices Time"		name_in_code="uVelocity"/>
 		<var name="vVelocity"				type="real"	dimensions="nVertices Time"		name_in_code="vVelocity"/>
 		<var name="uVelocityCell"			type="real"	dimensions="nCells Time"		name_in_code="uVelocityCell"/>
@@ -3691,10 +3699,10 @@
 		<var name="vVelocityInitial"			type="real"	dimensions="nVertices Time"		name_in_code="vVelocityInitial"/>
 		<var name="edgeVelocity"			type="real"	dimensions="nEdges Time"		name_in_code="edgeVelocity"/>
 		<var name="normalVectorEdge"			type="real"	dimensions="TWO maxEdges nCells Time"	name_in_code="normalVectorEdge"/>
-		<var name="solveStress"			type="integer"	dimensions="nCells Time"		name_in_code="solveStress"/>
+		<var name="solveStress"			type="integer"	dimensions="nCells Time"	name_in_code="solveStress"/>
 		<var name="solveVelocity"			type="integer"	dimensions="nVertices Time"		name_in_code="solveVelocity"/>
 		<var name="solveVelocityPrevious"		type="integer"	dimensions="nVertices Time"		name_in_code="solveVelocityPrevious"/>
-		<var name="icePressure"			type="real"	dimensions="nCells Time"		name_in_code="icePressure"/>
+		<var name="icePressure"			type="real"	dimensions="nCells Time"	name_in_code="icePressure"/>
 		<var name="stressDivergenceU"			type="real"	dimensions="nVertices Time"		name_in_code="stressDivergenceU"/>
 		<var name="stressDivergenceV"			type="real"	dimensions="nVertices Time"		name_in_code="stressDivergenceV"/>
 		<var name="airStressCellU"			type="real"	dimensions="nCells Time"		name_in_code="airStressCellU"/>
@@ -3722,7 +3730,7 @@
 	<var_struct name="velocity_weak" time_levs="1" packages="pkgWeak">
 		<var name="normalVectorPolygon"		type="real"	dimensions="TWO maxEdges nCells"		name_in_code="normalVectorPolygon"/>
 		<var name="normalVectorTriangle"		type="real"	dimensions="TWO vertexDegree nVertices"	name_in_code="normalVectorTriangle"/>
-		<var name="latCellRotated"			type="real"	dimensions="nCells"				name_in_code="latCellRotated"/>
+		<var name="latCellRotated"			type="real"	dimensions="nCells"name_in_code="latCellRotated"/>
 		<var name="latVertexRotated"			type="real"	dimensions="nVertices"				name_in_code="latVertexRotated"/>
 		<var name="strain11weak"			type="real"	dimensions="nCells Time"			name_in_code="strain11"/>
 		<var name="strain22weak"			type="real"	dimensions="nCells Time"			name_in_code="strain22"/>
@@ -3753,7 +3761,7 @@
 		<var name="principalStress1Var"		type="real"	dimensions="maxEdges nCells Time"		name_in_code="principalStress1"/>
 		<var name="principalStress2Var"		type="real"	dimensions="maxEdges nCells Time"		name_in_code="principalStress2"/>
 		<var name="replacementPressureVar"		type="real"	dimensions="maxEdges nCells Time"		name_in_code="replacementPressure"/>
-		<var name="variationalDenominator"	type="real"	dimensions="nVertices"				name_in_code="variationalDenominator"/>
+		<var name="variationalDenominator"	type="real"	dimensions="nVertices"		name_in_code="variationalDenominator"/>
 	</var_struct>
 
 	<!-- weak strain / variational stress divergence -->
@@ -3794,11 +3802,11 @@
 		<var name="lateralIceMelt"			type="real"	dimensions="nCells Time"		name_in_code="lateralIceMelt"/>
 		<var name="snowMelt"				type="real"	dimensions="nCells Time"		name_in_code="snowMelt"/>
 		<var name="snowMeltCategory"			type="real"	dimensions="nCategories nCells Time"	name_in_code="snowMeltCategory"/>
-		<var name="congelation"			type="real"	dimensions="nCells Time"		name_in_code="congelation"/>
+		<var name="congelation"			type="real"	dimensions="nCells Time"	name_in_code="congelation"/>
 		<var name="congelationCategory"		type="real"	dimensions="nCategories nCells Time"	name_in_code="congelationCategory"/>
 		<var name="snowiceFormation"			type="real"	dimensions="nCells Time"		name_in_code="snowiceFormation"/>
 		<var name="snowiceFormationCategory"		type="real"	dimensions="nCategories nCells Time"	name_in_code="snowiceFormationCategory"/>
-		<var name="snowThicknessChange"		type="real"	dimensions="nCells Time"		name_in_code="snowThicknessChange"/>
+		<var name="snowThicknessChange"		type="real"	dimensions="nCells Time"	name_in_code="snowThicknessChange"/>
 		<var name="snowThicknessChangeCategory"	type="real"	dimensions="nCategories nCells Time"	name_in_code="snowThicknessChangeCategory"/>
 		<var name="frazilFormation"			type="real"	dimensions="nCells Time"		name_in_code="frazilFormation"/>
 		<var name="frazilGrowthDiagnostic"		type="real"	dimensions="nCells Time"		name_in_code="frazilGrowthDiagnostic"/>
@@ -3820,7 +3828,7 @@
 
 	<!-- fluxes with the ocean -->
 	<var_struct name="ocean_fluxes" time_levs="1" packages="pkgColumnPackage">
-		<var name="oceanFreshWaterFlux"		type="real"	dimensions="nCells Time"		name_in_code="oceanFreshWaterFlux"/>
+		<var name="oceanFreshWaterFlux"		type="real"	dimensions="nCells Time"	name_in_code="oceanFreshWaterFlux"/>
 		<var name="oceanSaltFlux"			type="real"	dimensions="nCells Time"		name_in_code="oceanSaltFlux"/>
 		<var name="oceanHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="oceanHeatFlux"/>
 		<var name="oceanShortwaveFlux"			type="real"	dimensions="nCells Time"		name_in_code="oceanShortwaveFlux"/>
@@ -3850,17 +3858,17 @@
 		<var name="atmosReferenceHumidity2mOcean"	type="real"	dimensions="nCells Time"		name_in_code="atmosReferenceHumidity2mOcean"/>
 		<var name="albedoVisibleDirectOcean"		type="real"	dimensions="nCells Time"		name_in_code="albedoVisibleDirectOcean"/>
 		<var name="albedoVisibleDiffuseOcean"		type="real"	dimensions="nCells Time"		name_in_code="albedoVisibleDiffuseOcean"/>
-		<var name="albedoIRDirectOcean"		type="real"	dimensions="nCells Time"		name_in_code="albedoIRDirectOcean"/>
+		<var name="albedoIRDirectOcean"		type="real"	dimensions="nCells Time"	name_in_code="albedoIRDirectOcean"/>
 		<var name="albedoIRDiffuseOcean"		type="real"	dimensions="nCells Time"		name_in_code="albedoIRDiffuseOcean"/>
 		<var name="longwaveUpOcean"			type="real"	dimensions="nCells Time"		name_in_code="longwaveUpOcean"/>
 		<var name="sensibleHeatFluxOcean"		type="real"	dimensions="nCells Time"		name_in_code="sensibleHeatFluxOcean"/>
-		<var name="latentHeatFluxOcean"		type="real"	dimensions="nCells Time"		name_in_code="latentHeatFluxOcean"/>
+		<var name="latentHeatFluxOcean"		type="real"	dimensions="nCells Time"	name_in_code="latentHeatFluxOcean"/>
 		<var name="evaporativeWaterFluxOcean"		type="real"	dimensions="nCells Time"		name_in_code="evaporativeWaterFluxOcean"/>
 	</var_struct>
 
 	<!-- shortwave radiation -->
 	<var_struct name="shortwave" time_levs="1" packages="pkgColumnPackage">
-		<var name="dayOfNextShortwaveCalculation"	type="real"	dimensions="Time"					name_in_code="dayOfNextShortwaveCalculation"/>
+		<var name="dayOfNextShortwaveCalculation"	type="real"	dimensions="Time"	name_in_code="dayOfNextShortwaveCalculation"/>
 		<var name="solarZenithAngleCosine"		type="real"	dimensions="nCells Time"				name_in_code="solarZenithAngleCosine"/>
 		<var name="albedoVisibleDirectCategory"	type="real"	dimensions="nCategories nCells Time"			name_in_code="albedoVisibleDirectCategory"/>
 		<var name="albedoVisibleDiffuseCategory"	type="real"	dimensions="nCategories nCells Time"			name_in_code="albedoVisibleDiffuseCategory"/>
@@ -3869,11 +3877,11 @@
 		<var name="albedoVisibleDirectCell"		type="real"	dimensions="nCells Time"				name_in_code="albedoVisibleDirectCell"/>
 		<var name="albedoVisibleDiffuseCell"		type="real"	dimensions="nCells Time"				name_in_code="albedoVisibleDiffuseCell"/>
 		<var name="albedoIRDirectCell"			type="real"	dimensions="nCells Time"				name_in_code="albedoIRDirectCell"/>
-		<var name="albedoIRDiffuseCell"		type="real"	dimensions="nCells Time"				name_in_code="albedoIRDiffuseCell"/>
+		<var name="albedoIRDiffuseCell"		type="real"	dimensions="nCells Time"	name_in_code="albedoIRDiffuseCell"/>
 		<var name="albedoVisibleDirectArea"		type="real"	dimensions="nCells Time"				name_in_code="albedoVisibleDirectArea"/>
 		<var name="albedoVisibleDiffuseArea"		type="real"	dimensions="nCells Time"				name_in_code="albedoVisibleDiffuseArea"/>
 		<var name="albedoIRDirectArea"			type="real"	dimensions="nCells Time"				name_in_code="albedoIRDirectArea"/>
-		<var name="albedoIRDiffuseArea"		type="real"	dimensions="nCells Time"				name_in_code="albedoIRDiffuseArea"/>
+		<var name="albedoIRDiffuseArea"		type="real"	dimensions="nCells Time"	name_in_code="albedoIRDiffuseArea"/>
 		<var name="shortwaveScalingFactor"		type="real"	dimensions="nCells Time"				name_in_code="shortwaveScalingFactor"/>
 		<var name="surfaceShortwaveFlux"		type="real"	dimensions="nCategories nCells Time"			name_in_code="surfaceShortwaveFlux"/>
 		<var name="interiorShortwaveFlux"		type="real"	dimensions="nCategories nCells Time"			name_in_code="interiorShortwaveFlux"/>
@@ -3908,7 +3916,7 @@
 		<var name="dragFreeboard"			type="real"	dimensions="nCells Time"		name_in_code="dragFreeboard"			packages="pkgColumnFormDrag"/>
 		<var name="dragIceSnowDraft"			type="real"	dimensions="nCells Time"		name_in_code="dragIceSnowDraft"		packages="pkgColumnFormDrag"/>
 		<var name="dragRidgeHeight"			type="real"	dimensions="nCells Time"		name_in_code="dragRidgeHeight"			packages="pkgColumnFormDrag"/>
-		<var name="dragRidgeSeparation"		type="real"	dimensions="nCells Time"		name_in_code="dragRidgeSeparation"		packages="pkgColumnFormDrag"/>
+		<var name="dragRidgeSeparation"		type="real"	dimensions="nCells Time"	name_in_code="dragRidgeSeparation"		packages="pkgColumnFormDrag"/>
 		<var name="dragKeelDepth"			type="real"	dimensions="nCells Time"		name_in_code="dragKeelDepth"			packages="pkgColumnFormDrag"/>
 		<var name="dragKeelSeparation"			type="real"	dimensions="nCells Time"		name_in_code="dragKeelSeparation"		packages="pkgColumnFormDrag"/>
 		<var name="dragFloeLength"			type="real"	dimensions="nCells Time"		name_in_code="dragFloeLength"			packages="pkgColumnFormDrag"/>
@@ -3952,7 +3960,7 @@
 	<!-- biogeochemistry -->
 	<var_struct name="biogeochemistry" time_levs="1" packages="pkgColumnBiogeochemistry">
 		<var name="newlyFormedIce"			type="integer"	dimensions="nCategories nCells"			name_in_code="newlyFormedIce"			packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
-		<var name="rayleighCriteriaReal"		type="real"	dimensions="nCells"					name_in_code="rayleighCriteriaReal"/>
+		<var name="rayleighCriteriaReal"		type="real"	dimensions="nCells"name_in_code="rayleighCriteriaReal"/>
 		<var name="atmosBioFluxes"			type="real"	dimensions="nZBGCTracers nCells Time"			name_in_code="atmosBioFluxes"/>
 		<var name="atmosIceBioFluxes"			type="real"	dimensions="nZBGCTracers nCells Time"			name_in_code="atmosIceBioFluxes"/>
 		<var name="snowIceBioFluxes"			type="real"	dimensions="nZBGCTracers nCells Time"			name_in_code="snowIceBioFluxes"/>
@@ -4082,7 +4090,7 @@
 			packages="pkgColumnBiogeochemistry;pkgTracerBrine"
 			icepack_name="hbrine"
 		/>
-		<var name="biologyGrid"			type="real"	dimensions="nBioLayersP2"				name_in_code="biologyGrid"			packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
+		<var name="biologyGrid"			type="real"	dimensions="nBioLayersP2"	name_in_code="biologyGrid"			packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
 		<var name="interfaceBiologyGrid"		type="real"	dimensions="nBioLayersP1"				name_in_code="interfaceBiologyGrid"		packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
 		<var name="verticalGrid"			type="real"	dimensions="nIceLayersP1"				name_in_code="verticalGrid"			packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
 		<var name="interfaceGrid"			type="real"	dimensions="nIceLayersP1"				name_in_code="interfaceGrid"/>
@@ -4107,7 +4115,7 @@
 	<var_struct name="regions" time_levs="1">
 		<var name="regionCellMasks"			type="integer"	dimensions="nRegions nCells"		name_in_code="regionCellMasks"/>
 		<var name="regionVertexMasks"			type="integer"	dimensions="nRegions nVertices"	name_in_code="regionVertexMasks"/>
-		<var name="regionNames"			type="text"	dimensions="nRegions"			name_in_code="regionNames"/>
+		<var name="regionNames"			type="text"	dimensions="nRegions"		name_in_code="regionNames"/>
 	</var_struct>
 
 	<!-- Diagnostics -->
@@ -4116,7 +4124,7 @@
 		<var name="simulationStartTime"		type="text"	dimensions=""/>
 		<var name="daysSinceStartOfSim"		type="real"	dimensions="Time"/>
 		<var name="meltOnset"				type="real"	dimensions="nCells Time"		name_in_code="meltOnset"/>
-		<var name="freezeOnset"			type="real"	dimensions="nCells Time"		name_in_code="freezeOnset"/>
+		<var name="freezeOnset"			type="real"	dimensions="nCells Time"	name_in_code="freezeOnset"/>
 		<var name="iceAreaTendencyTransport"		type="real"	dimensions="nCells Time"		name_in_code="iceAreaTendencyTransport"/>
 		<var name="iceVolumeTendencyTransport"		type="real"	dimensions="nCells Time"		name_in_code="iceVolumeTendencyTransport"/>
 		<var name="iceAgeTendencyTransport"		type="real"	dimensions="nCells Time"		name_in_code="iceAgeTendencyTransport"/>
@@ -4124,7 +4132,7 @@
 		<var name="iceVolumeTendencyThermodynamics"	type="real"	dimensions="nCells Time"		name_in_code="iceVolumeTendencyThermodynamics"/>
 		<var name="iceAgeTendencyThermodynamics"	type="real"	dimensions="nCells Time"		name_in_code="iceAgeTendencyThermodynamics"/>
 		<var name="freezingMeltingPotentialInitial"	type="real"	dimensions="nCells Time"		name_in_code="freezingMeltingPotentialInitial"/>
-		<var name="timeAverageTestVariable"		type="real"	dimensions="Time"			name_in_code="timeAverageTestVariable"/>
+		<var name="timeAverageTestVariable"		type="real"	dimensions="Time"	name_in_code="timeAverageTestVariable"/>
 	</var_struct>
 
 	<!-- Testing of testing system -->

--- a/src/Registry.xml
+++ b/src/Registry.xml
@@ -2574,10 +2574,10 @@
 		<var name="skeletalNitrateConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalNitrateConcCell"		packages="pkgTracerSkeletalNitrate"/>
 		<var name="skeletalSilicateConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalSilicateConcCell"	packages="pkgTracerSkeletalSilicate"/>
 		<var name="skeletalAmmoniumConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalAmmoniumConcCell"	packages="pkgTracerSkeletalAmmonium"/>
-		<var name="skeletalDMSConcCell"		type="real"	dimensions="ONE nCells Timename_in_code="skeletalDMSConcCell"		packages="pkgTracerSkeletalDMS"/>
+		<var name="skeletalDMSConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalDMSConcCell"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPpConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalDMSPpConcCell"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPdConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalDMSPdConcCell"		packages="pkgTracerSkeletalDMS"/>
-		<var name="skeletalNonreactiveConcCell"	type="real"	dimensions="ONE nCells Timename_in_code="skeletalNonreactiveConcCell"	packages="pkgTracerSkeletalNonreactive"/>
+		<var name="skeletalNonreactiveConcCell"	type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalNonreactiveConcCell"	packages="pkgTracerSkeletalNonreactive"/>
 		<var name="skeletalHumicsConcCell"		type="real"	dimensions="ONE nCells Time"			name_in_code="skeletalHumicsConcCell"		packages="pkgTracerSkeletalHumics"/>
 		<var name="skeletalParticulateIronConcCell"	type="real"	dimensions="nParticulateIron nCells Time"	name_in_code="skeletalParticulateIronConcCell"	packages="pkgTracerSkeletalIron"/>
 		<var name="skeletalDissolvedIronConcCell"	type="real"	dimensions="nDissolvedIron nCells Time"	name_in_code="skeletalDissolvedIronConcCell"	packages="pkgTracerSkeletalIron"/>
@@ -2602,10 +2602,10 @@
 		<var name="verticalNitrateSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalNitrateSnowCell"		packages="pkgTracerVerticalNitrate"/>
 		<var name="verticalSilicateSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalSilicateSnowCell"	packages="pkgTracerVerticalSilicate"/>
 		<var name="verticalAmmoniumSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalAmmoniumSnowCell"	packages="pkgTracerVerticalAmmonium"/>
-		<var name="verticalDMSSnowCell"		type="real"	dimensions="TWO nCells Timename_in_code="verticalDMSSnowCell"		packages="pkgTracerVerticalDMS"/>
+		<var name="verticalDMSSnowCell"		type="real"	dimensions="TWO nCells Time"		name_in_code="verticalDMSSnowCell"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPpSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalDMSPpSnowCell"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPdSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalDMSPdSnowCell"		packages="pkgTracerVerticalDMS"/>
-		<var name="verticalNonreactiveSnowCell"	type="real"	dimensions="TWO nCells Timename_in_code="verticalNonreactiveSnowCell"	packages="pkgTracerVerticalNonreactive"/>
+		<var name="verticalNonreactiveSnowCell"	type="real"	dimensions="TWO nCells Time"			name_in_code="verticalNonreactiveSnowCell"	packages="pkgTracerVerticalNonreactive"/>
 		<var name="verticalHumicsSnowCell"		type="real"	dimensions="TWO nCells Time"			name_in_code="verticalHumicsSnowCell"		packages="pkgTracerVerticalHumics"/>
 		<var name="verticalParticulateIronSnowCell"	type="real"	dimensions="nPartIronSnowLayers nCells Time"	name_in_code="verticalParticulateIronSnowCell"	packages="pkgTracerVerticalIron"/>
 		<var name="verticalDissolvedIronSnowCell"	type="real"	dimensions="nDisIronSnowLayers nCells Time"	name_in_code="verticalDissolvedIronSnowCell"	packages="pkgTracerVerticalIron"/>
@@ -3349,7 +3349,7 @@
 		<var name="verticalSalinityGrady"		type="real"	dimensions="nBioLayers nCategories nCells"		name_in_code="verticalSalinityGrady"			packages="pkgTracerZSalinity"/>
 	</var_struct>
 	<var_struct name="tracer_conservation" time_levs="2">
-		<var name="iceAreaCategoryCons"		type="real"	dimensions="ONE nCategoriesname_in_code="iceAreaCategoryCons"/>
+		<var name="iceAreaCategoryCons"		type="real"	dimensions="ONE nCategories"		name_in_code="iceAreaCategoryCons"/>
 		<var name="iceVolumeCategoryCons"		type="real"	dimensions="ONE nCategories"				name_in_code="iceVolumeCategoryCons"/>
 		<var name="snowVolumeCategoryCons"		type="real"	dimensions="ONE nCategories"				name_in_code="snowVolumeCategoryCons"/>
 		<var name="surfaceTemperatureCons"		type="real"	dimensions="ONE nCategories"				name_in_code="surfaceTemperatureCons"/>
@@ -3380,10 +3380,10 @@
 		<var name="skeletalNitrateConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalNitrateConcCons"		packages="pkgTracerSkeletalNitrate"/>
 		<var name="skeletalSilicateConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalSilicateConcCons"	packages="pkgTracerSkeletalSilicate"/>
 		<var name="skeletalAmmoniumConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalAmmoniumConcCons"	packages="pkgTracerSkeletalAmmonium"/>
-		<var name="skeletalDMSConcCons"		type="real"	dimensions="ONE nCategoriesname_in_code="skeletalDMSConcCons"		packages="pkgTracerSkeletalDMS"/>
+		<var name="skeletalDMSConcCons"		type="real"	dimensions="ONE nCategories"		name_in_code="skeletalDMSConcCons"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPpConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalDMSPpConcCons"		packages="pkgTracerSkeletalDMS"/>
 		<var name="skeletalDMSPdConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalDMSPdConcCons"		packages="pkgTracerSkeletalDMS"/>
-		<var name="skeletalNonreactiveConcCons"	type="real"	dimensions="ONE nCategoriesname_in_code="skeletalNonreactiveConcCons"	packages="pkgTracerSkeletalNonreactive"/>
+		<var name="skeletalNonreactiveConcCons"	type="real"	dimensions="ONE nCategories"		name_in_code="skeletalNonreactiveConcCons"	packages="pkgTracerSkeletalNonreactive"/>
 		<var name="skeletalHumicsConcCons"		type="real"	dimensions="ONE nCategories"				name_in_code="skeletalHumicsConcCons"		packages="pkgTracerSkeletalHumics"/>
 		<var name="skeletalParticulateIronConcCons"	type="real"	dimensions="nParticulateIron nCategories"		name_in_code="skeletalParticulateIronConcCons"	packages="pkgTracerSkeletalIron"/>
 		<var name="skeletalDissolvedIronConcCons"	type="real"	dimensions="nDissolvedIron nCategories"		name_in_code="skeletalDissolvedIronConcCons"	packages="pkgTracerSkeletalIron"/>
@@ -3394,10 +3394,10 @@
 		<var name="verticalNitrateSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalNitrateSnowCons"		packages="pkgTracerVerticalNitrate"/>
 		<var name="verticalSilicateSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalSilicateSnowCons"	packages="pkgTracerVerticalSilicate"/>
 		<var name="verticalAmmoniumSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalAmmoniumSnowCons"	packages="pkgTracerVerticalAmmonium"/>
-		<var name="verticalDMSSnowCons"		type="real"	dimensions="TWO nCategoriesname_in_code="verticalDMSSnowCons"		packages="pkgTracerVerticalDMS"/>
+		<var name="verticalDMSSnowCons"		type="real"	dimensions="TWO nCategories"		name_in_code="verticalDMSSnowCons"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPpSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalDMSPpSnowCons"		packages="pkgTracerVerticalDMS"/>
 		<var name="verticalDMSPdSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalDMSPdSnowCons"		packages="pkgTracerVerticalDMS"/>
-		<var name="verticalNonreactiveSnowCons"	type="real"	dimensions="TWO nCategoriesname_in_code="verticalNonreactiveSnowCons"	packages="pkgTracerVerticalNonreactive"/>
+		<var name="verticalNonreactiveSnowCons"	type="real"	dimensions="TWO nCategories"		name_in_code="verticalNonreactiveSnowCons"	packages="pkgTracerVerticalNonreactive"/>
 		<var name="verticalHumicsSnowCons"		type="real"	dimensions="TWO nCategories"				name_in_code="verticalHumicsSnowCons"		packages="pkgTracerVerticalHumics"/>
 		<var name="verticalParticulateIronSnowCons"	type="real"	dimensions="nPartIronSnowLayers nCategories"		name_in_code="verticalParticulateIronSnowCons"	packages="pkgTracerVerticalIron"/>
 		<var name="verticalDissolvedIronSnowCons"	type="real"	dimensions="nDisIronSnowLayers nCategories"		name_in_code="verticalDissolvedIronSnowCons"	packages="pkgTracerVerticalIron"/>
@@ -3579,7 +3579,7 @@
 		<var name="iCellTriangle"			type="integer"	dimensions="nTriPerEdgeRemap nEdges"			name_in_code="iCellTriangle"/>
 		<var name="triangleArea"			type="real"	dimensions="nTriPerEdgeRemap nEdges"			name_in_code="triangleArea"/>
 		<var name="departurePoint"			type="real"	dimensions="TWO nVertices"				name_in_code="departurePoint"/>
-		<var name="remapEdge"				type="integer"	dimensions="nEdges"name_in_code="remapEdge"/>
+		<var name="remapEdge"				type="integer"	dimensions="nEdges"	name_in_code="remapEdge"/>
 		<var name="cellsOnEdgeRemap"			type="integer"	dimensions="maxCellsPerEdgeRemap nEdges"		name_in_code="cellsOnEdgeRemap"/>
 		<var name="edgesOnEdgeRemap"			type="integer"	dimensions="maxEdgesPerEdgeRemap nEdges"		name_in_code="edgesOnEdgeRemap"/>
 		<var name="xVertexOnCell"			type="real"	dimensions="maxEdges nCells"				name_in_code="xVertexOnCell"/>
@@ -3588,27 +3588,27 @@
 		<var name="yVertexOnEdge"			type="real"	dimensions="maxVerticesPerEdgeRemap nEdges"		name_in_code="yVertexOnEdge"/>
 		<var name="transCellToGlobal"			type="real"	dimensions="R3 R3 nCells"				name_in_code="transCellToGlobal"/>
 		<var name="transGlobalToCell"			type="real"	dimensions="R3 R3 nCells"				name_in_code="transGlobalToCell"/>
-		<var name="transVertexToGlobal"		type="real"	dimensions="R3 R3 nVerticesname_in_code="transVertexToGlobal"/>
-		<var name="transGlobalToVertex"		type="real"	dimensions="R3 R3 nVerticesname_in_code="transGlobalToVertex"/>
+		<var name="transVertexToGlobal"		type="real"	dimensions="R3 R3 nVertices"		name_in_code="transVertexToGlobal"/>
+		<var name="transGlobalToVertex"		type="real"	dimensions="R3 R3 nVertices"		name_in_code="transGlobalToVertex"/>
 		<var name="transEdgeToGlobal"			type="real"	dimensions="R3 R3 nEdges"				name_in_code="transEdgeToGlobal"/>
 		<var name="transGlobalToEdge"			type="real"	dimensions="R3 R3 nEdges"				name_in_code="transGlobalToEdge"/>
 		<var name="minLengthEdgesOnVertex"		type="real"	dimensions="nVertices"					name_in_code="minLengthEdgesOnVertex"/>
-		<var name="xAvgCell"				type="real"	dimensions="nCells"name_in_code="xAvgCell"/>
-		<var name="yAvgCell"				type="real"	dimensions="nCells"name_in_code="yAvgCell"/>
-		<var name="xxAvgCell"				type="real"	dimensions="nCells"name_in_code="xxAvgCell"/>
-		<var name="xyAvgCell"				type="real"	dimensions="nCells"name_in_code="xyAvgCell"/>
-		<var name="yyAvgCell"				type="real"	dimensions="nCells"name_in_code="yyAvgCell"/>
-		<var name="xxxAvgCell"				type="real"	dimensions="nCells"name_in_code="xxxAvgCell"/>
-		<var name="xxyAvgCell"				type="real"	dimensions="nCells"name_in_code="xxyAvgCell"/>
-		<var name="xyyAvgCell"				type="real"	dimensions="nCells"name_in_code="xyyAvgCell"/>
-		<var name="yyyAvgCell"				type="real"	dimensions="nCells"name_in_code="yyyAvgCell"/>
+		<var name="xAvgCell"				type="real"	dimensions="nCells"	name_in_code="xAvgCell"/>
+		<var name="yAvgCell"				type="real"	dimensions="nCells"	name_in_code="yAvgCell"/>
+		<var name="xxAvgCell"				type="real"	dimensions="nCells"	name_in_code="xxAvgCell"/>
+		<var name="xyAvgCell"				type="real"	dimensions="nCells"	name_in_code="xyAvgCell"/>
+		<var name="yyAvgCell"				type="real"	dimensions="nCells"	name_in_code="yyAvgCell"/>
+		<var name="xxxAvgCell"				type="real"	dimensions="nCells"	name_in_code="xxxAvgCell"/>
+		<var name="xxyAvgCell"				type="real"	dimensions="nCells"	name_in_code="xxyAvgCell"/>
+		<var name="xyyAvgCell"				type="real"	dimensions="nCells"	name_in_code="xyyAvgCell"/>
+		<var name="yyyAvgCell"				type="real"	dimensions="nCells"	name_in_code="yyyAvgCell"/>
 		<var name="xxxxAvgCell"			type="real"	dimensions="nCells"		name_in_code="xxxxAvgCell"/>
 		<var name="xxxyAvgCell"			type="real"	dimensions="nCells"		name_in_code="xxxyAvgCell"/>
 		<var name="xxyyAvgCell"			type="real"	dimensions="nCells"		name_in_code="xxyyAvgCell"/>
 		<var name="xyyyAvgCell"			type="real"	dimensions="nCells"		name_in_code="xyyyAvgCell"/>
 		<var name="yyyyAvgCell"			type="real"	dimensions="nCells"		name_in_code="yyyyAvgCell"/>
-		<var name="maskEdge"				type="integer"	dimensions="nEdges"name_in_code="maskEdge"/>
-		<var name="maskCell"				type="integer"	dimensions="nCells"name_in_code="maskCell"/>
+		<var name="maskEdge"				type="integer"	dimensions="nEdges"	name_in_code="maskEdge"/>
+		<var name="maskCell"				type="integer"	dimensions="nCells"	name_in_code="maskCell"/>
 		<var name="maskCategoryCell"			type="integer"	dimensions="nCategories nCells"			name_in_code="maskCategoryCell"/>
 		<var name="workCategoryCell"			type="real"	dimensions="nCategories nCells"			name_in_code="workCategoryCell"/>
 	</var_struct>
@@ -3730,7 +3730,7 @@
 	<var_struct name="velocity_weak" time_levs="1" packages="pkgWeak">
 		<var name="normalVectorPolygon"		type="real"	dimensions="TWO maxEdges nCells"		name_in_code="normalVectorPolygon"/>
 		<var name="normalVectorTriangle"		type="real"	dimensions="TWO vertexDegree nVertices"	name_in_code="normalVectorTriangle"/>
-		<var name="latCellRotated"			type="real"	dimensions="nCells"name_in_code="latCellRotated"/>
+		<var name="latCellRotated"			type="real"	dimensions="nCells"	name_in_code="latCellRotated"/>
 		<var name="latVertexRotated"			type="real"	dimensions="nVertices"				name_in_code="latVertexRotated"/>
 		<var name="strain11weak"			type="real"	dimensions="nCells Time"			name_in_code="strain11"/>
 		<var name="strain22weak"			type="real"	dimensions="nCells Time"			name_in_code="strain22"/>
@@ -3960,7 +3960,7 @@
 	<!-- biogeochemistry -->
 	<var_struct name="biogeochemistry" time_levs="1" packages="pkgColumnBiogeochemistry">
 		<var name="newlyFormedIce"			type="integer"	dimensions="nCategories nCells"			name_in_code="newlyFormedIce"			packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
-		<var name="rayleighCriteriaReal"		type="real"	dimensions="nCells"name_in_code="rayleighCriteriaReal"/>
+		<var name="rayleighCriteriaReal"		type="real"	dimensions="nCells"	name_in_code="rayleighCriteriaReal"/>
 		<var name="atmosBioFluxes"			type="real"	dimensions="nZBGCTracers nCells Time"			name_in_code="atmosBioFluxes"/>
 		<var name="atmosIceBioFluxes"			type="real"	dimensions="nZBGCTracers nCells Time"			name_in_code="atmosIceBioFluxes"/>
 		<var name="snowIceBioFluxes"			type="real"	dimensions="nZBGCTracers nCells Time"			name_in_code="snowIceBioFluxes"/>


### PR DESCRIPTION
This PR implements the prescribed seaice cover mode in mpas-seaice. This was already an option in E3SM. The hooks in the nuopc cap had to be uncommented, and routines brought over from the E3SM source and translated to their cesm and nuopc equivalents.

With the PR, users will able to specify MPASSI%PRES in the F2000climo compset in place of CICE. In create_newcase use:
--compset 2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV

The seaice cover produced by MPASSI and CICE is identical in test runs, the climates differ slightly.

This PR should permit us to bypass NVHPC issues with CICE.

Caveat: this compset will be susceptible to mpas framework issues just like the fully coupled model.