### PR TITLE
Gnu prescribed ice

### DIFF
--- a/driver_nuopc/ice_import_export.F90
+++ b/driver_nuopc/ice_import_export.F90
@@ -1790,10 +1790,10 @@ contains
     integer, pointer :: model_year_align    ! align stream_year_first
                                    ! with this model year
 !DD    character(len=strKIND), pointer :: stream_fldVarName
-    character(len=1024), pointer :: stream_fldFileNameIn
-    character(len=1024), pointer :: stream_meshfile
-    character(len=1024), pointer :: stream_mapalgo
-    character(len=1024) :: stream_fldFileName(nFilesMaximum)
+    character(len=512), pointer :: stream_fldFileNameIn
+    character(len=512), pointer :: stream_meshfile
+    character(len=512), pointer :: stream_mapalgo
+    character(len=512) :: stream_fldFileName(nFilesMaximum)
 !DD    character(len=strKIND), pointer :: stream_domTvarName
 !DD    character(len=strKIND), pointer :: stream_domXvarName
 !DD    character(len=strKIND), pointer :: stream_domYvarName


### PR DESCRIPTION
The code copied from E3SM to enable prescribed ice cover fails to compile with the GNU compiler.
Changing the character string length of 1024 to length 512 in in this new code fixes this.