### PR TITLE
Add config_dt for 60km to 3.75km oQU grids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,21 @@
 .mpas_core_seaice
 default_inputs/
 namelist.seaice
+streams.seaice
 seaice_model
 src/Registry_processed.xml
 src/default_inputs/
 src/inc/
-streams.seaice
+
+# Ignore compiled python
+buildnmlc
+buildcppc
+
+# Ignore editor temporaries and backups
+*~
+.#*
+\#*#
+*.swp
+
+# Ignore python bytecode files
+*.pyc

--- a/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -6,7 +6,7 @@
 <!-- seaice_model -->
 <config_dt>1800.0</config_dt>
 <config_dt ice_grid="oQU480">7200.0</config_dt>
-<config_dt ice_grid="oQU240">7200.0</config_dt>
+<config_dt ice_grid="oQU240">3600.0</config_dt>
 <config_dt ice_grid="oQU240wLI">7200.0</config_dt>
 <config_dt ice_grid="oQU120">1800.0</config_dt>
 <config_dt ice_grid="oQU060">900.0</config_dt>

--- a/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -8,7 +8,12 @@
 <config_dt ice_grid="oQU480">7200.0</config_dt>
 <config_dt ice_grid="oQU240">7200.0</config_dt>
 <config_dt ice_grid="oQU240wLI">7200.0</config_dt>
-<config_dt ice_grid="oQU120">3600.0</config_dt>
+<config_dt ice_grid="oQU120">1800.0</config_dt>
+<config_dt ice_grid="oQU060">900.0</config_dt>
+<config_dt ice_grid="oQU030">450.0</config_dt>
+<config_dt ice_grid="oQU015">240.0</config_dt>
+<config_dt ice_grid="oQU0075">120.0</config_dt>
+<config_dt ice_grid="oQU00375">60.0</config_dt>
 <config_dt ice_grid="oEC60to30v3">1800.0</config_dt>
 <config_dt ice_grid="oEC60to30v3wLI">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E1r2">1800.0</config_dt>


### PR DESCRIPTION
This is an attempt to use the namelist files to select the `config_dt` for mpas-si instead of doing it in an user_nl_mpassi file or by shell commands.

Important context for these values: https://github.com/EarthWorksOrg/EarthWorks/pull/45#issuecomment-2118165239