### PR TITLE
Copy mpassi config_archive entry from E3SM

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -1,0 +1,21 @@
+<components version="2.0">
+
+  <comp_archive_spec compname="mpassi" compclass="ice" exclude_testing="true">
+    <rest_file_extension>rst</rest_file_extension>
+    <rest_file_extension>rst.am.timeSeriesStatsMonthly</rest_file_extension>
+    <hist_file_extension>hist</hist_file_extension>
+    <rest_history_varname>unset</rest_history_varname>
+    <rpointer>
+      <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
+      <rpointer_content>$MPAS_DATENAME</rpointer_content>
+    </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.ice</tfile>
+      <tfile disposition="copy">casename.mpassi.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mpassi.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">casename.mpassi.hist.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">casename.mpassi.hist.am.regionalStatistics.0001.01.nc</tfile>
+    </test_file_names>
+  </comp_archive_spec>
+
+</components>


### PR DESCRIPTION
This entry will allow the short and long term archiver scripts to handle MPAS-SI appropriately. This will allow the cime create_test workflow to mark the ARCHIVE step as a success.

This entry is copied from
[E3SM-Project/E3SM:cime_config/config_archive.xml](https://github.com/E3SM-Project/E3SM/blob/264a352acdbbdc161db76cfbd3622db8829c07bf/cime_config/config_archive.xml#L84-L100)