### PR TITLE
Add timers to mpas-seaice

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -224,7 +224,7 @@ def _build_mpassi():
         # build the library
         makefile = os.path.join(casetools, "Makefile")
         complib = os.path.join(libroot, "libice.a")
-        cmd = "{} complib -j {} MODEL=mpassi COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -DMPAS_PIO_SUPPORT -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NAMELIST_SUFFIX=seaice\" FIXEDFLAGS={} {}" \
+        cmd = "{} complib -j {} MODEL=mpassi COMPLIB={} -f {} USER_CPPDEFS=\"-DUSE_PIO2 -DMPAS_PIO_SUPPORT -D_MPI -DEXCLUDE_INIT_MODE -DMPAS_NO_ESMF_INIT -DMPAS_EXTERNAL_ESMF_LIB -DMPAS_PERF_MOD_TIMERS -DMPAS_NAMELIST_SUFFIX=seaice\" FIXEDFLAGS={} {}" \
             .format(gmake, gmake_j, complib, makefile, fixedflags, get_standard_makefile_args(case))
 
         rc, out, err = run_cmd(cmd, from_dir=os.path.join(objroot, "ice", "obj"))


### PR DESCRIPTION
Timers are now enabled by default by adding a preprocessor directive to the compilation of mpas-seaice. The timing output is added to the ESMF_Profile.summary file.