### PR TITLE
Update 15km file defaults

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -154,9 +154,9 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oQU015':
-        decomp_date = '230907'
+        decomp_date = '241221'
         decomp_prefix = 'mpas-o.graph.info.QU015.'
-        grid_date = '230907'
+        grid_date = '241221'
         grid_prefix = 'ocean.QU.015km'
         if ice_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")


### PR DESCRIPTION
The default ocean/seaice files for 15km have been updated to use a new one that does not initially generate unstable transients.

These modifications are in the mpas-ocean, mpas-seaice, and ccs_config components.