### PR TITLE
Bit-for-bit restartability established for mpas-seaice

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -1017,6 +1017,7 @@ add_default($nl, 'config_AM_regionalStatistics_output_stream');
 add_default($nl, 'config_AM_regionalStatistics_compute_on_startup');
 add_default($nl, 'config_AM_regionalStatistics_write_on_startup');
 add_default($nl, 'config_AM_regionalStatistics_ice_extent_limit');
+add_default($nl, 'config_AM_regionalStatistics_backward_output_offset');
 
 #########################################
 # Namelist group: AM_ridgingDiagnostics #

--- a/bld/build-namelist-section
+++ b/bld/build-namelist-section
@@ -527,6 +527,7 @@ add_default($nl, 'config_AM_regionalStatistics_output_stream');
 add_default($nl, 'config_AM_regionalStatistics_compute_on_startup');
 add_default($nl, 'config_AM_regionalStatistics_write_on_startup');
 add_default($nl, 'config_AM_regionalStatistics_ice_extent_limit');
+add_default($nl, 'config_AM_regionalStatistics_backward_output_offset');
 
 #########################################
 # Namelist group: AM_ridgingDiagnostics #

--- a/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -462,6 +462,7 @@
 <config_AM_regionalStatistics_compute_on_startup>true</config_AM_regionalStatistics_compute_on_startup>
 <config_AM_regionalStatistics_write_on_startup>true</config_AM_regionalStatistics_write_on_startup>
 <config_AM_regionalStatistics_ice_extent_limit>0.15</config_AM_regionalStatistics_ice_extent_limit>
+<config_AM_regionalStatistics_backward_output_offset>'00-00-01_00:00:00'</config_AM_regionalStatistics_backward_output_offset>
 
 <!-- AM_ridgingDiagnostics -->
 <config_AM_ridgingDiagnostics_enable>true</config_AM_ridgingDiagnostics_enable>
@@ -575,7 +576,7 @@
 <config_AM_timeSeriesStatsMonthly_enable prognostic_mode="prescribed">false</config_AM_timeSeriesStatsMonthly_enable>
 <config_AM_timeSeriesStatsMonthly_compute_on_startup>false</config_AM_timeSeriesStatsMonthly_compute_on_startup>
 <config_AM_timeSeriesStatsMonthly_write_on_startup>false</config_AM_timeSeriesStatsMonthly_write_on_startup>
-<config_AM_timeSeriesStatsMonthly_compute_interval>'0000-00-00_01:00:00'</config_AM_timeSeriesStatsMonthly_compute_interval>
+<config_AM_timeSeriesStatsMonthly_compute_interval>'dt'</config_AM_timeSeriesStatsMonthly_compute_interval>
 <config_AM_timeSeriesStatsMonthly_output_stream>'timeSeriesStatsMonthlyOutput'</config_AM_timeSeriesStatsMonthly_output_stream>
 <config_AM_timeSeriesStatsMonthly_restart_stream>'none'</config_AM_timeSeriesStatsMonthly_restart_stream>
 <config_AM_timeSeriesStatsMonthly_operation>'avg'</config_AM_timeSeriesStatsMonthly_operation>

--- a/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2877,6 +2877,14 @@ Valid values: real value between 0 and 1
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_AM_regionalStatistics_backward_output_offset" type="char*1024"
+	category="AM_regionalStatistics" group="AM_regionalStatistics">
+Backward offset for filename timestamps when writing the output stream
+
+Valid values: A time interval in YYYY-MM-DD_hh:mm:ss.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- AM_ridgingDiagnostics -->
 

--- a/driver_nuopc/ice_comp_nuopc.F90
+++ b/driver_nuopc/ice_comp_nuopc.F90
@@ -39,7 +39,8 @@ module ice_comp_nuopc
   use seaice_forcing, only : post_atmospheric_coupling, post_oceanic_coupling,   &
                              seaice_forcing_get, seaice_forcing_write_restart_times
   use seaice_analysis_driver, only : seaice_analysis_precompute, seaice_analysis_compute, &
-                             seaice_analysis_restart, seaice_analysis_write
+                             seaice_analysis_restart, seaice_analysis_write,   &
+                             seaice_analysis_compute_startup
   use seaice_initialize, only : seaice_init_post_clock_advance
   use seaice_core_interface, only : seaice_setup_core, seaice_setup_domain
   use seaice_time_integration, only : seaice_timestep
@@ -379,6 +380,10 @@ contains
     character(*), parameter     :: F00   = "('(ice_comp_nuopc) ',2a,1x,d21.14)"
     character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
 
+    type (block_type), pointer :: block_ptr
+    type (mpas_pool_type), pointer :: statePool, &
+                                      forcingPool
+
     interface
        subroutine xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
           use iso_c_binding, only : c_char, c_ptr, c_int
@@ -404,6 +409,7 @@ contains
     !--------------------------------
 
     rc = ESMF_SUCCESS
+    errorCode = ESMF_SUCCESS
     if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
 
 
@@ -817,23 +823,30 @@ contains
 !    !DD there hase to be a better way to go from esmf type to MPAS_Time_Type
     call ESMF_TimeGet(Ecurrtime, s_i8=s_e, sn_i8=sn_e, sd_i8=sd_e, yy=yy_e, calendar = ecalendar, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    !currtime%t%basetime%S  = s_e
-    !currtime%t%basetime%Sn = sn_e
-    !currtime%t%basetime%Sd = sd_e
-    !currtime%t%yr = yy_e
-    currtime%t = EcurrTime
+#ifdef DATMFORCEDRESTORING
+    currtime%t%basetime%S  = s_e
+    currtime%t%basetime%Sn = sn_e
+    currtime%t%basetime%Sd = sd_e
+    currtime%t%yr = yy_e
 
-!    call ESMF_CalendarGet(Ecalendar, calkindflag=type_e, rc=rc)
-!    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_CalendarGet(Ecalendar, calkindflag=type_e, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-!    if(type_e == ESMF_CALKIND_NOLEAP) then
-!       currTime%t%calendar => noleapCal
-!    elseif(type_e == ESMF_CALKIND_GREGORIAN) then
-!       currTime%t%calendar => gregorianCal
-!    else
-!       rc = 1
-!       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-!    endif
+    if(type_e == ESMF_CALKIND_NOLEAP) then
+       currTime%t%calendar => noleapCal
+    elseif(type_e == ESMF_CALKIND_GREGORIAN) then
+       currTime%t%calendar => gregorianCal
+    else
+       rc = 1
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    endif
+
+#else
+    currtime%t = Ecurrtime
+
+    call ESMF_CalendarGet(Ecalendar, calkindflag=type_e, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+#endif
 
     if (runtype == 'initial') then
        call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_START_TIME, ierr)
@@ -988,6 +1001,51 @@ contains
     call ice_export (exportState, flds_scalar_name, domain_ptr,    &
                      errorCode, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    if (errorCode /= 0) then
+       call mpas_log_write('ERROR in ice_export', MPAS_LOG_CRIT)
+    endif
+
+!    ! Setup clock for initial runs
+!    if (runtype == "continue" .or. runtype == "branch" ) then
+!       block_ptr => domain_ptr % blocklist
+!       do while(associated(block_ptr))
+!          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+!          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+!
+!          call ice_time_average_coupled_init(forcingPool)
+!          call ice_time_average_coupled_accumulate(statePool, forcingPool, 1)
+!          block_ptr => block_ptr % next
+!       end do
+!    end if
+
+!-----------------------------------------------------------------------
+!
+!   get initial state from driver
+!
+!-----------------------------------------------------------------------
+
+    !timeStep = mpas_get_clock_timestep(domain_ptr % clock, ierr=ierr)
+    call ESMF_ClockGet(clock, timeStep=timeStep, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    !call mpas_get_timeInterval(timeStep, dt=dt)
+    call ESMF_TimeIntervalGet( timeStep, s=ice_cpl_dt, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ice_import(importState, flds_scalar_name, domain_ptr,  &
+                       errorCode, rc)
+    if (errorCode /= 0) then
+       call mpas_log_write('Error in ice_import', MPAS_LOG_CRIT)
+    endif
+
+    itimestep = 0
+
+    call seaice_analysis_compute_startup(domain_ptr, ierr)
+
+    ! Reset all output alarms, to prevent intial time step from writing any output, unless it's ringing.
+    call mpas_stream_mgr_reset_alarms(domain_ptr % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
+    call mpas_stream_mgr_reset_alarms(domain_ptr % streamManager, direction=MPAS_STREAM_INPUT, ierr=ierr)
+
 
     !DDcall State_SetScalar(dble(nx_global), flds_scalar_index_nx, exportState, &
     !DD     flds_scalar_name, flds_scalar_num, rc)

--- a/src/analysis_members/Registry_seaice_regional_statistics.xml
+++ b/src/analysis_members/Registry_seaice_regional_statistics.xml
@@ -23,6 +23,13 @@
 			description="sea-ice fraction limit for ice extent."
 			possible_values="real value between 0 and 1"
 		/>
+                <nml_option name="config_AM_regionalStatistics_backward_output_offset"
+                                        type="character"
+                                        default_value="00-00-01_00:00:00"
+                                        units="unitless"
+                                        description="Backward offset for filename timestamps when writing the output stream"
+                                        possible_values="A time interval in YYYY-MM-DD_hh:mm:ss."
+		/>
 	</nml_record>
 	<packages>
 		<package name="regionalStatisticsAMPKG" description="This package includes variables required for the regionalStatistics analysis member."/>


### PR DESCRIPTION
ice_comp_nuopc.F90 had its import of coupler fields fixed and this now establishes bit-for-bit restartability of the restart files for mpas-seaice. Some modifications to defaults for diagnostic output were made so that restarted runs produce bit-for-bit reproducible output as well for some of the diagnostics. Monthly and daily mean time average output is not yet reproducible as the first time step after initialization fails to accumulate