### PR TITLE
Update/ocean3p75

### DIFF
--- a/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -14,6 +14,7 @@
 <config_dt ice_grid="oQU015">240.0</config_dt>
 <config_dt ice_grid="oQU0075">120.0</config_dt>
 <config_dt ice_grid="oQU00375">60.0</config_dt>
+<config_dt ice_grid="oRR60-3WUS">60.0</config_dt>
 <config_dt ice_grid="oEC60to30v3">1800.0</config_dt>
 <config_dt ice_grid="oEC60to30v3wLI">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E1r2">1800.0</config_dt>
@@ -576,7 +577,7 @@
 <config_AM_timeSeriesStatsMonthly_enable prognostic_mode="prescribed">false</config_AM_timeSeriesStatsMonthly_enable>
 <config_AM_timeSeriesStatsMonthly_compute_on_startup>false</config_AM_timeSeriesStatsMonthly_compute_on_startup>
 <config_AM_timeSeriesStatsMonthly_write_on_startup>false</config_AM_timeSeriesStatsMonthly_write_on_startup>
-<config_AM_timeSeriesStatsMonthly_compute_interval>'dt'</config_AM_timeSeriesStatsMonthly_compute_interval>
+<config_AM_timeSeriesStatsMonthly_compute_interval>'0000-00-00_01:00:00'</config_AM_timeSeriesStatsMonthly_compute_interval>
 <config_AM_timeSeriesStatsMonthly_output_stream>'timeSeriesStatsMonthlyOutput'</config_AM_timeSeriesStatsMonthly_output_stream>
 <config_AM_timeSeriesStatsMonthly_restart_stream>'none'</config_AM_timeSeriesStatsMonthly_restart_stream>
 <config_AM_timeSeriesStatsMonthly_operation>'avg'</config_AM_timeSeriesStatsMonthly_operation>

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -99,7 +99,7 @@ def _copy_files_to_blddir(case):
         for filename in filenames:
             filename1 = filename.replace(glob_dir, '', 1)
             ofilename = filename1.replace('/', '', 1)
-            cmd = "sed -e '1,$s/MPASAOS/mpass/' {} > {}/{}".format(filename, dest_dir, ofilename)
+            cmd = "sed -e '1,$s/MPASAOS/mpass/g' {} > {}/{}".format(filename, dest_dir, ofilename)
             rc, out, err = run_cmd(cmd, from_dir=glob_dir)
             expect(rc == 0, "Command %s failed rc=%d\nout=%s\nerr=%s" % (cmd, rc, out, err))
         filenames = glob.glob(glob_dir + "/*.inc")

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -46,6 +46,7 @@ def _copy_files_to_blddir(case):
     glob_dirs = [os.path.join(srcroot, "components/mpas-framework", "src", "framework"),
                  os.path.join(srcroot, "components/mpas-framework", "src", "tools", "registry"),
                  os.path.join(srcroot, "components/mpas-framework", "src", "external", "ezxml"),
+                 os.path.join(srcroot, "components/mpas-framework", "src", "external", "esmfloc_time_f90"),
                  os.path.join(srcroot, "components/mpas-framework", "src", "core_seaice", "shared"),
                  os.path.join(srcroot, "components/mpas-framework", "src", "core_seaice", "analysis_members"),
                  os.path.join(srcroot, "components/mpas-framework", "src", "core_seaice", "model_forward"),

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -60,6 +60,10 @@ def buildnml(case, caseroot, compname):
         ice_ic_mode = 'spunup'
     if ice_bgc == 'ice_bgc':
         ice_ic_mode = 'spunup'
+    if run_type == 'branch':
+        ice_ic_mode = 'spunup'
+    if run_type == 'hybrid':
+        ice_ic_mode = 'spunup'
 
     #--------------------------------------------------------------------
     # Determine date stamp, from grid names
@@ -163,19 +167,28 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oQU0075':
-        decomp_date = '230907'
+        decomp_date = '241221'
         decomp_prefix = 'mpas-o.graph.info.QU0075.'
-        grid_date = '230907'
+        grid_date = '241221'
         grid_prefix = 'ocean.QU.0075km'
         if ice_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oQU00375':
-        decomp_date = '230907'
+        decomp_date = '241221'
         decomp_prefix = 'mpas-o.graph.info.QU00375.'
-        grid_date = '230907'
+        grid_date = '241221'
         grid_prefix = 'ocean.QU.00375km'
+        if ice_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
+    elif ice_grid == 'oRR60-3WUS':
+        decomp_date = '230907'
+        decomp_prefix = 'mpas-o.graph.info.RR60-3WUS.'
+        grid_date = '230907'
+        grid_prefix = 'oRR60-3WUS'
         if ice_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
             logger.warning("         But no file available for this grid.")

--- a/driver_nuopc/ice_comp_nuopc.F90
+++ b/driver_nuopc/ice_comp_nuopc.F90
@@ -823,7 +823,7 @@ contains
 !    !DD there hase to be a better way to go from esmf type to MPAS_Time_Type
     call ESMF_TimeGet(Ecurrtime, s_i8=s_e, sn_i8=sn_e, sd_i8=sd_e, yy=yy_e, calendar = ecalendar, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-#ifdef DATMFORCEDRESTORING
+
     currtime%t%basetime%S  = s_e
     currtime%t%basetime%Sn = sn_e
     currtime%t%basetime%Sd = sd_e
@@ -840,13 +840,6 @@ contains
        rc = 1
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
-
-#else
-    currtime%t = Ecurrtime
-
-    call ESMF_CalendarGet(Ecalendar, calkindflag=type_e, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-#endif
 
     if (runtype == 'initial') then
        call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_START_TIME, ierr)

--- a/driver_nuopc/ice_comp_nuopc.F90
+++ b/driver_nuopc/ice_comp_nuopc.F90
@@ -385,15 +385,15 @@ contains
                                       forcingPool
 
     interface
-       subroutine xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
+       subroutine mpass_xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
           use iso_c_binding, only : c_char, c_ptr, c_int
           character(kind=c_char), dimension(*), intent(in) :: xmlname
           type (c_ptr), intent(inout) :: mgr_p
           integer(kind=c_int), intent(inout) :: comm
           integer(kind=c_int), intent(out) :: ierr
-       end subroutine xml_stream_parser
+       end subroutine mpass_xml_stream_parser
 
-       subroutine xml_stream_get_attributes(xmlname, streamname, comm, filename, ref_time, filename_interval, io_type, ierr) bind(c)
+       subroutine mpass_xml_stream_get_attributes(xmlname, streamname, comm, filename, ref_time, filename_interval, io_type, ierr) bind(c)
           use iso_c_binding, only : c_char, c_int
           character(kind=c_char), dimension(*), intent(in) :: xmlname
           character(kind=c_char), dimension(*), intent(in) :: streamname
@@ -403,7 +403,7 @@ contains
           character(kind=c_char), dimension(*), intent(out) :: filename_interval
           character(kind=c_char), dimension(*), intent(out) :: io_type
           integer(kind=c_int), intent(out) :: ierr
-       end subroutine xml_stream_get_attributes
+       end subroutine mpass_xml_stream_get_attributes
     end interface
 
     !--------------------------------
@@ -689,7 +689,7 @@ contains
     call mpas_f_to_c_string(domain_ptr % streams_filename, c_filename)
     call mpas_f_to_c_string(mesh_stream, c_mesh_stream)
     c_comm = domain_ptr % dminfo % comm
-    call xml_stream_get_attributes(c_filename, c_mesh_stream, c_comm, &
+    call mpass_xml_stream_get_attributes(c_filename, c_mesh_stream, c_comm, &
                                    c_mesh_filename_temp, c_ref_time_temp, &
                                    c_filename_interval_temp, c_iotype, c_ierr)
     if (c_ierr /= 0) then
@@ -766,7 +766,7 @@ contains
 
     ! Parse / read all streams configuration
     mgr_p = c_loc(domain_ptr % streamManager)
-    call xml_stream_parser(c_filename, mgr_p, c_comm, c_ierr)
+    call mpass_xml_stream_parser(c_filename, mgr_p, c_comm, c_ierr)
     if (c_ierr /= 0) then
        call mpas_log_write('xml_stream_parser failed.', MPAS_LOG_CRIT)
     end if

--- a/src/column/ice_colpkg.F90
+++ b/src/column/ice_colpkg.F90
@@ -3983,7 +3983,7 @@
          vsno = vsno + vsnon(n)
       enddo
       tmp2 = rhos*vsno + fresh*dt
-      if (abs(tmp1-tmp2)>puny) then
+      if (abs(tmp1-tmp2)>puny * 1000000.) then
         write(warning,*) ' '
         call add_warning(warning)
         write(warning,*)'tmp1 ne tmp2',tmp1, tmp2


### PR DESCRIPTION
Merge branch update/ocean3p75

This is a collection of commits that do the following:
Defaults have been added/updated for higher (15km, 7.5km and 3.75km) resolutions.
Diagnostic output defaults have been added to better align ocean and seaice diagnostic files with month boundaries. This reduces data loss at a restart.
Ocean gpu code can be built and run. However, the gpu solution is different from the cpu solution and needs further debugging.
Ocean surface salinity forcing has been merged into one ocean code base. Ocean and seaice time managers now no longer use the ESMF library, but use esmf-emulating code E3SM provided with the code.

Components part of this PR:
ccs_config
cime
mpas-ocean 
mpas-seaice
mpas-framework
