### PR TITLE
Enable initialization with a spun-up IC

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -488,20 +488,19 @@ def buildnml(case, caseroot, compname):
             lines.append('                  output_interval="00-00-00_00:00:01" />')
             lines.append('')
 
-            if ice_ic_mode == 'spunup':
-                lines.append('<immutable_stream name="restart_ic"')
-                lines.append('                  type="input"')
-                if ice_grid.startswith("oRRS1"):
-                    lines.append('                  io_type="pnetcdf,cdf5"')
-                elif ice_grid.startswith("oQU"):
-                    lines.append('                  io_type="pnetcdf,cdf5"')
-                else:
-                    lines.append('                  io_type="{}"'.format(ice_pio_typename))
+            lines.append('<immutable_stream name="restart_ic"')
+            lines.append('                  type="input"')
+            if ice_grid.startswith("oRRS1"):
+                lines.append('                  io_type="pnetcdf,cdf5"')
+            elif ice_grid.startswith("oQU"):
+                lines.append('                  io_type="pnetcdf,cdf5"')
+            else:
+                lines.append('                  io_type="{}"'.format(ice_pio_typename))
 
-                lines.append('                  filename_template="{}"'.format(input_file))
-                lines.append('                  filename_interval="none"')
-                lines.append('                  input_interval="initial_only" />')
-                lines.append('')
+            lines.append('                  filename_template="{}"'.format(input_file))
+            lines.append('                  filename_interval="none"')
+            lines.append('                  input_interval="initial_only" />')
+            lines.append('')
 
             lines.append('<stream name="output"')
             lines.append('        type="output"')


### PR DESCRIPTION
This allows buildnml to always include the restart_ic stream in streams.seaice, which the user
can then edit to allow initialization with a spun-up IC.